### PR TITLE
replace include with input

### DIFF
--- a/main.tex
+++ b/main.tex
@@ -42,24 +42,24 @@
 %
 
 \frontmatter
-\include{chapters/abstract}
+\input{chapters/abstract}
 \tableofcontents
 \listoffigures
 \listoftables
-% \include{chapters/notation}
+% \input{chapters/notation}
 
 \mainmatter
-\include{chapters/intro}
-\include{chapters/customize}
-\include{chapters/table}
-\include{chapters/math}
+\input{chapters/intro}
+\input{chapters/customize}
+\input{chapters/table}
+\input{chapters/math}
 \bibliography{bib/tex}
 
 \appendix
 \chapter{论文规范}
 
 \backmatter
-\include{chapters/acknowledgements}
-\include{chapters/publications}
+\input{chapters/acknowledgements}
+\input{chapters/publications}
 
 \end{document}


### PR DESCRIPTION
`\input{A}`和`\include{A}`的区别：

`\input{A}`相当于直接把A文件的内容复制到目标文件中。
`\include{A}`除了执行`\input{A}`之外，还在A文件的前后加上了`\clearpage`以及为A文件生成单独的`.aux`文件。

由于`\include`会自动加上`\clearpage`，所以只使用于include整章内容。而实际写论文的时候，有些人可能会喜欢一节一个tex文件，此时用`\include`就会出问题。

所以更安全的方式还是用`\input`。