### PR TITLE
Link DOIs to preferred resolver

### DIFF
--- a/ustcauthoryear.bst
+++ b/ustcauthoryear.bst
@@ -1750,7 +1750,7 @@ FUNCTION {begin.bib}
   write$ newline$
   "\providecommand{\href}[2]{\url{#2}}"
   write$ newline$
-  "\providecommand{\doi}[1]{DOI: \href{http://dx.doi.org/#1}{#1}}"
+  "\providecommand{\doi}[1]{DOI: \href{https://doi.org/#1}{#1}}"
   write$ newline$
   "\expandafter\ifx\csname urlstyle\endcsname\relax\relax\else"
   write$ newline$

--- a/ustcbachelor.bst
+++ b/ustcbachelor.bst
@@ -1606,7 +1606,7 @@ FUNCTION {begin.bib}
   write$ newline$
   "\providecommand{\href}[2]{\url{#2}}"
   write$ newline$
-  "\providecommand{\doi}[1]{DOI: \href{http://dx.doi.org/#1}{#1}}"
+  "\providecommand{\doi}[1]{DOI: \href{https://doi.org/#1}{#1}}"
   write$ newline$
   "\expandafter\ifx\csname urlstyle\endcsname\relax\relax\else"
   write$ newline$

--- a/ustcnumerical.bst
+++ b/ustcnumerical.bst
@@ -1615,7 +1615,7 @@ FUNCTION {begin.bib}
   write$ newline$
   "\providecommand{\href}[2]{\url{#2}}"
   write$ newline$
-  "\providecommand{\doi}[1]{DOI: \href{http://dx.doi.org/#1}{#1}}"
+  "\providecommand{\doi}[1]{DOI: \href{https://doi.org/#1}{#1}}"
   write$ newline$
   "\expandafter\ifx\csname urlstyle\endcsname\relax\relax\else"
   write$ newline$

--- a/ustcthesis.dtx
+++ b/ustcthesis.dtx
@@ -4598,7 +4598,7 @@ FUNCTION {begin.bib}
   write$ newline$
   "\providecommand{\href}[2]{\url{#2}}"
   write$ newline$
-  "\providecommand{\doi}[1]{DOI: \href{http://dx.doi.org/#1}{#1}}"
+  "\providecommand{\doi}[1]{DOI: \href{https://doi.org/#1}{#1}}"
   write$ newline$
   "\expandafter\ifx\csname urlstyle\endcsname\relax\relax\else"
   write$ newline$


### PR DESCRIPTION
Hello :-)

The DOI foundation recommends [this new, secure resolver](https://www.doi.org/doi_handbook/3_Resolution.html#3.8). Accordingly, this PR updates static the commands that generate new DOI links.

Cheers!