### PR TITLE
修复表格内容文字行距过小的问题

### DIFF
--- a/ustcthesis.cls
+++ b/ustcthesis.cls
@@ -2514,7 +2514,8 @@
 \patchcmd\@floatboxreset{%
   \normalsize
 }{%
-  \small
+%   \small
+    \fontsize{10.5bp}{17.5bp}\selectfont
 }{}{\ustc@patch@error{\@floatboxreset}}
 
 % 对 \pkg{longtable} 跨页表格进行相同的设置。
@@ -2525,7 +2526,8 @@
 %    \begin{macrocode}
 \AtEndOfPackageFile*{longtable}{
   \AtBeginEnvironment{longtable}{%
-    \small
+%     \small
+    \fontsize{10.5bp}{17.5bp}\selectfont
   }
 }
 


### PR DESCRIPTION
第 2479 行为 Caption 设置的行距，会作用于表格内字体设置的 `\small` 命令，导致表格内字体的行距非常小。修复方案按照第 593 行中规定的 small 的字号和行距，重新设置了表格内的字号和行距。
我提交的这种修复，应该只能临时应急，因为 `\small` 命令应用于正文时，行距应该依然不对。