### PR TITLE
Fix: Github actions and l3build check

### DIFF
--- a/.github/workflows/install-packages.sh
+++ b/.github/workflows/install-packages.sh
@@ -16,4 +16,5 @@ FONT_PKGS="fandol tex-gyre xits";
 EXTRA_PKGS="$ALGORITHM2E_PKGS $BIBLATEX_PKGS booktabs $NOMENCL_PKGS siunitx";
 DOC_PKGS="hypdoc listings xcolor";
 
+tlmgr update --self
 tlmgr install $BIN_PKGS $REQUIRED_PKGS $FONT_PKGS $EXTRA_PKGS $DOC_PKGS;

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -9,7 +9,7 @@ jobs:
     if: "!contains(github.event.head_commit.message, 'ci skip')"
     container: tunathu/thuthesis-test-env
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - name: Install required packages
       run: bash .github/workflows/install-packages.sh
     - name: Test thesis

--- a/test/testfiles-biblatex/biblatex-authoryear.tlg
+++ b/test/testfiles-biblatex/biblatex-authoryear.tlg
@@ -882,8 +882,7 @@ Completed box being shipped out [2]
 ..\vbox(700.50723+0.0)x417.11752, glue set 554.42151fil
 ...\write-{}
 ...\write-{}
-...\write1{\@writefile{toc}{\protect \contentsline {chapter}{参考文献}{\thepage \ET
-C.}
+...\write1{\@writefile{toc}{\protect \contentsline {chapter}{参考文献}{\thepage }{}\protected@file@percent }}
 ...\marks1{\protect \ustc@spacetitle  {参考文献}}
 ...\marks2{\prg_do_nothing: }
 ...\mark{{\protect \ustc@spacetitle  {参考文献}}{}}

--- a/test/testfiles-biblatex/biblatex-bachelor.tlg
+++ b/test/testfiles-biblatex/biblatex-bachelor.tlg
@@ -679,8 +679,7 @@ Completed box being shipped out [2]
 ..\vbox(700.50723+0.0)x417.11752, glue set 476.7346fil
 ...\write-{}
 ...\write-{}
-...\write1{\@writefile{toc}{\protect \contentsline {chapter}{参考文献}{\thepage \ET
-C.}
+...\write1{\@writefile{toc}{\protect \contentsline {chapter}{参考文献}{\thepage }{}\protected@file@percent }}
 ...\write1{\@writefile{lof}{\protect \addvspace {10.0pt}}}
 ...\write1{\@writefile{lot}{\protect \addvspace {10.0pt}}}
 ...\glue(\topskip) 12.0

--- a/test/testfiles-biblatex/biblatex-inline.tlg
+++ b/test/testfiles-biblatex/biblatex-inline.tlg
@@ -426,8 +426,7 @@ Completed box being shipped out [2]
 ..\vbox(700.50723+0.0)x417.11752, glue set >20000.0fil
 ...\write-{}
 ...\write-{}
-...\write1{\@writefile{toc}{\protect \contentsline {chapter}{参考文献}{\thepage \ET
-C.}
+...\write1{\@writefile{toc}{\protect \contentsline {chapter}{参考文献}{\thepage }{}\protected@file@percent }}
 ...\marks1{\protect \ustc@spacetitle  {参考文献}}
 ...\marks2{\prg_do_nothing: }
 ...\mark{{\protect \ustc@spacetitle  {参考文献}}{}}

--- a/test/testfiles-biblatex/biblatex-numeric.tlg
+++ b/test/testfiles-biblatex/biblatex-numeric.tlg
@@ -678,8 +678,7 @@ Completed box being shipped out [2]
 ..\vbox(700.50723+0.0)x417.11752, glue set >20000.0fil
 ...\write-{}
 ...\write-{}
-...\write1{\@writefile{toc}{\protect \contentsline {chapter}{参考文献}{\thepage \ET
-C.}
+...\write1{\@writefile{toc}{\protect \contentsline {chapter}{参考文献}{\thepage }{}\protected@file@percent }}
 ...\marks1{\protect \ustc@spacetitle  {参考文献}}
 ...\marks2{\prg_do_nothing: }
 ...\mark{{\protect \ustc@spacetitle  {参考文献}}{}}

--- a/test/testfiles-bibtex/bibtex-authoryear.tlg
+++ b/test/testfiles-bibtex/bibtex-authoryear.tlg
@@ -1056,8 +1056,7 @@ Completed box being shipped out [2]
 ..\vbox(700.50723+0.0)x417.11752, glue set 554.42151fil
 ...\write-{}
 ...\write-{}
-...\write1{\@writefile{toc}{\protect \contentsline {chapter}{参考文献}{\thepage \ET
-C.}
+...\write1{\@writefile{toc}{\protect \contentsline {chapter}{参考文献}{\thepage }{}\protected@file@percent }}
 ...\marks1{\protect \ustc@spacetitle  {参考文献}}
 ...\marks2{\prg_do_nothing: }
 ...\mark{{\protect \ustc@spacetitle  {参考文献}}{}}

--- a/test/testfiles-bibtex/bibtex-bachelor.tlg
+++ b/test/testfiles-bibtex/bibtex-bachelor.tlg
@@ -616,8 +616,7 @@ Completed box being shipped out [2]
 ..\vbox(700.50723+0.0)x417.11752, glue set 476.7346fil
 ...\write-{}
 ...\write-{}
-...\write1{\@writefile{toc}{\protect \contentsline {chapter}{参考文献}{\thepage \ET
-C.}
+...\write1{\@writefile{toc}{\protect \contentsline {chapter}{参考文献}{\thepage }{}\protected@file@percent }}
 ...\write1{\@writefile{lof}{\protect \addvspace {10.0pt}}}
 ...\write1{\@writefile{lot}{\protect \addvspace {10.0pt}}}
 ...\glue(\topskip) 12.0

--- a/test/testfiles-bibtex/bibtex-inline.tlg
+++ b/test/testfiles-bibtex/bibtex-inline.tlg
@@ -531,8 +531,7 @@ Completed box being shipped out [2]
 ..\vbox(700.50723+0.0)x417.11752, glue set >20000.0fil
 ...\write-{}
 ...\write-{}
-...\write1{\@writefile{toc}{\protect \contentsline {chapter}{参考文献}{\thepage \ET
-C.}
+...\write1{\@writefile{toc}{\protect \contentsline {chapter}{参考文献}{\thepage }{}\protected@file@percent }}
 ...\marks1{\protect \ustc@spacetitle  {参考文献}}
 ...\marks2{\prg_do_nothing: }
 ...\mark{{\protect \ustc@spacetitle  {参考文献}}{}}

--- a/test/testfiles-bibtex/bibtex-numerical.tlg
+++ b/test/testfiles-bibtex/bibtex-numerical.tlg
@@ -607,8 +607,7 @@ Completed box being shipped out [2]
 ..\vbox(700.50723+0.0)x417.11752, glue set >20000.0fil
 ...\write-{}
 ...\write-{}
-...\write1{\@writefile{toc}{\protect \contentsline {chapter}{参考文献}{\thepage \ET
-C.}
+...\write1{\@writefile{toc}{\protect \contentsline {chapter}{参考文献}{\thepage }{}\protected@file@percent }}
 ...\marks1{\protect \ustc@spacetitle  {参考文献}}
 ...\marks2{\prg_do_nothing: }
 ...\mark{{\protect \ustc@spacetitle  {参考文献}}{}}

--- a/test/testfiles-crossref/main-bachelor-arabic.tlg
+++ b/test/testfiles-crossref/main-bachelor-arabic.tlg
@@ -967,7 +967,7 @@ Completed box being shipped out [2]
 ...\write-{}
 ...\write1{\@writefile{toc}{\protect \addvspace {12bp}}}
 ...\write1{\pp@pagectr{footnote}{1}{\theabspage }{\thepage }}
-...\write1{\@writefile{toc}{\protect \contentsline {chapter}{\protect \numberline \ETC.}
+...\write1{\@writefile{toc}{\protect \contentsline {chapter}{\protect \numberline {第1章}简介}{\thepage }{}\protected@file@percent }}
 ...\write1{\@writefile{lof}{\protect \addvspace {10.0pt}}}
 ...\write1{\@writefile{lot}{\protect \addvspace {10.0pt}}}
 ...\glue(\topskip) 12.0
@@ -1045,7 +1045,7 @@ Completed box being shipped out [2]
 ....\penalty 10000
 ....\glue(\parfillskip) 0.0
 ....\glue(\rightskip) 0.0 plus 1.0fil
-...\write1{\@writefile{toc}{\protect \contentsline {section}{\protect \numberline \ETC.}
+...\write1{\@writefile{toc}{\protect \contentsline {section}{\protect \numberline {1.1}一级节标题}{\thepage }{}\protected@file@percent }}
 ...\penalty 10000
 ...\glue 6.02249
 ...\glue(\parskip) 0.0
@@ -1084,7 +1084,7 @@ Completed box being shipped out [2]
 ....\penalty 10000
 ....\glue(\parfillskip) 0.0 plus 1.0fil
 ....\glue(\rightskip) 0.0
-...\write1{\@writefile{toc}{\protect \contentsline {subsection}{\protect \numberline \ETC.}
+...\write1{\@writefile{toc}{\protect \contentsline {subsection}{\protect \numberline {1.1.1}二级节标题}{\thepage }{}\protected@file@percent }}
 ...\penalty 10000
 ...\glue 6.02249
 ...\glue(\parskip) 0.0
@@ -1127,7 +1127,7 @@ Completed box being shipped out [2]
 ....\penalty 10000
 ....\glue(\parfillskip) 0.0 plus 1.0fil
 ....\glue(\rightskip) 0.0
-...\write1{\@writefile{toc}{\protect \contentsline {subsubsection}{\protect \numberline \ETC.}
+...\write1{\@writefile{toc}{\protect \contentsline {subsubsection}{\protect \numberline {1}三级节标题}{\thepage }{}\protected@file@percent }}
 ...\penalty 10000
 ...\glue 0.0
 ...\glue(\parskip) 0.0
@@ -1176,7 +1176,7 @@ Completed box being shipped out [2]
 ....\penalty 10000
 ....\glue(\parfillskip) 0.0 plus 1.0fil
 ....\glue(\rightskip) 0.0
-...\write1{\@writefile{toc}{\protect \contentsline {paragraph}{\protect \numberline \ETC.}
+...\write1{\@writefile{toc}{\protect \contentsline {paragraph}{\protect \numberline {（1）}四级节标题}{\thepage }{}\protected@file@percent }}
 ...\penalty 10000
 ...\glue 0.0
 ...\glue(\parskip) 0.0
@@ -1212,7 +1212,7 @@ Completed box being shipped out [2]
 ....\penalty 10000
 ....\glue(\parfillskip) 0.0 plus 1.0fil
 ....\glue(\rightskip) 0.0
-...\write1{\@writefile{toc}{\protect \contentsline {subparagraph}{五级节标题\ETC.}
+...\write1{\@writefile{toc}{\protect \contentsline {subparagraph}{五级节标题}{\thepage }{}\protected@file@percent }}
 ...\penalty 10000
 ...\glue 0.0
 ...\glue(\parskip) 0.0
@@ -1363,7 +1363,7 @@ Completed box being shipped out [3]
 ...\write-{}
 ...\write1{\@writefile{toc}{\protect \addvspace {12bp}}}
 ...\write1{\pp@pagectr{footnote}{2}{\theabspage }{\thepage }}
-...\write1{\@writefile{toc}{\protect \contentsline {chapter}{\protect \numberline \ETC.}
+...\write1{\@writefile{toc}{\protect \contentsline {chapter}{\protect \numberline {第2章}浮动体}{\thepage }{}\protected@file@percent }}
 ...\write1{\@writefile{lof}{\protect \addvspace {10.0pt}}}
 ...\write1{\@writefile{lot}{\protect \addvspace {10.0pt}}}
 ...\glue(\topskip) 12.0
@@ -1537,8 +1537,7 @@ Completed box being shipped out [4]
 ..\vbox(700.50723+0.0)x417.11752, glue set 610.39568fil
 ...\write-{}
 ...\write1{\@writefile{toc}{\protect \addvspace {12bp}}}
-...\write1{\@writefile{toc}{\protect \contentsline {chapter}{参考文献}{\thepage \ET
-C.}
+...\write1{\@writefile{toc}{\protect \contentsline {chapter}{参考文献}{\thepage }{}\protected@file@percent }}
 ...\write1{\@writefile{lof}{\protect \addvspace {10.0pt}}}
 ...\write1{\@writefile{lot}{\protect \addvspace {10.0pt}}}
 ...\glue(\topskip) 12.0
@@ -1774,7 +1773,7 @@ Completed box being shipped out [5]
 ..\vbox(700.50723+0.0)x417.11752, glue set 633.65005fil
 ...\write-{}
 ...\write1{\pp@pagectr{footnote}{3}{\theabspage }{\thepage }}
-...\write1{\@writefile{toc}{\protect \contentsline {chapter}{\protect \numberline \ETC.}
+...\write1{\@writefile{toc}{\protect \contentsline {chapter}{\protect \numberline {附录 A}附录章节}{\thepage }{}\protected@file@percent }}
 ...\write1{\@writefile{lof}{\protect \addvspace {10.0pt}}}
 ...\write1{\@writefile{lot}{\protect \addvspace {10.0pt}}}
 ...\glue(\topskip) 12.0
@@ -1956,8 +1955,7 @@ Completed box being shipped out [6]
 ..\vbox(700.50723+0.0)x417.11752, glue set 587.5086fil
 ...\write-{}
 ...\write-{}
-...\write1{\@writefile{toc}{\protect \contentsline {chapter}{致谢}{\thepage }{\ET
-C.}
+...\write1{\@writefile{toc}{\protect \contentsline {chapter}{致谢}{\thepage }{}\protected@file@percent }}
 ...\write1{\@writefile{lof}{\protect \addvspace {10.0pt}}}
 ...\write1{\@writefile{lot}{\protect \addvspace {10.0pt}}}
 ...\glue(\topskip) 12.0

--- a/test/testfiles-crossref/main-bachelor-english.tlg
+++ b/test/testfiles-crossref/main-bachelor-english.tlg
@@ -951,7 +951,7 @@ Completed box being shipped out [2]
 ...\write-{}
 ...\write1{\@writefile{toc}{\protect \addvspace {12bp}}}
 ...\write1{\pp@pagectr{footnote}{1}{\theabspage }{\thepage }}
-...\write1{\@writefile{toc}{\protect \contentsline {chapter}{\protect \numberline \ETC.}
+...\write1{\@writefile{toc}{\protect \contentsline {chapter}{\protect \numberline {Chapter 1}简介}{\thepage }{}\protected@file@percent }}
 ...\write1{\@writefile{lof}{\protect \addvspace {10.0pt}}}
 ...\write1{\@writefile{lot}{\protect \addvspace {10.0pt}}}
 ...\glue(\topskip) 12.0
@@ -1027,7 +1027,7 @@ Completed box being shipped out [2]
 ....\penalty 10000
 ....\glue(\parfillskip) 0.0
 ....\glue(\rightskip) 0.0 plus 1.0fil
-...\write1{\@writefile{toc}{\protect \contentsline {section}{\protect \numberline \ETC.}
+...\write1{\@writefile{toc}{\protect \contentsline {section}{\protect \numberline {1.1}一级节标题}{\thepage }{}\protected@file@percent }}
 ...\penalty 10000
 ...\glue 6.02249
 ...\glue(\parskip) 0.0
@@ -1066,7 +1066,7 @@ Completed box being shipped out [2]
 ....\penalty 10000
 ....\glue(\parfillskip) 0.0 plus 1.0fil
 ....\glue(\rightskip) 0.0
-...\write1{\@writefile{toc}{\protect \contentsline {subsection}{\protect \numberline \ETC.}
+...\write1{\@writefile{toc}{\protect \contentsline {subsection}{\protect \numberline {1.1.1}二级节标题}{\thepage }{}\protected@file@percent }}
 ...\penalty 10000
 ...\glue 6.02249
 ...\glue(\parskip) 0.0
@@ -1109,7 +1109,7 @@ Completed box being shipped out [2]
 ....\penalty 10000
 ....\glue(\parfillskip) 0.0 plus 1.0fil
 ....\glue(\rightskip) 0.0
-...\write1{\@writefile{toc}{\protect \contentsline {subsubsection}{\protect \numberline \ETC.}
+...\write1{\@writefile{toc}{\protect \contentsline {subsubsection}{\protect \numberline {1}三级节标题}{\thepage }{}\protected@file@percent }}
 ...\penalty 10000
 ...\glue 0.0
 ...\glue(\parskip) 0.0
@@ -1158,7 +1158,7 @@ Completed box being shipped out [2]
 ....\penalty 10000
 ....\glue(\parfillskip) 0.0 plus 1.0fil
 ....\glue(\rightskip) 0.0
-...\write1{\@writefile{toc}{\protect \contentsline {paragraph}{\protect \numberline \ETC.}
+...\write1{\@writefile{toc}{\protect \contentsline {paragraph}{\protect \numberline {（1）}四级节标题}{\thepage }{}\protected@file@percent }}
 ...\penalty 10000
 ...\glue 0.0
 ...\glue(\parskip) 0.0
@@ -1194,7 +1194,7 @@ Completed box being shipped out [2]
 ....\penalty 10000
 ....\glue(\parfillskip) 0.0 plus 1.0fil
 ....\glue(\rightskip) 0.0
-...\write1{\@writefile{toc}{\protect \contentsline {subparagraph}{五级节标题\ETC.}
+...\write1{\@writefile{toc}{\protect \contentsline {subparagraph}{五级节标题}{\thepage }{}\protected@file@percent }}
 ...\penalty 10000
 ...\glue 0.0
 ...\glue(\parskip) 0.0
@@ -1345,7 +1345,7 @@ Completed box being shipped out [3]
 ...\write-{}
 ...\write1{\@writefile{toc}{\protect \addvspace {12bp}}}
 ...\write1{\pp@pagectr{footnote}{2}{\theabspage }{\thepage }}
-...\write1{\@writefile{toc}{\protect \contentsline {chapter}{\protect \numberline \ETC.}
+...\write1{\@writefile{toc}{\protect \contentsline {chapter}{\protect \numberline {Chapter 2}浮动体}{\thepage }{}\protected@file@percent }}
 ...\write1{\@writefile{lof}{\protect \addvspace {10.0pt}}}
 ...\write1{\@writefile{lot}{\protect \addvspace {10.0pt}}}
 ...\glue(\topskip) 12.0
@@ -1517,7 +1517,7 @@ Completed box being shipped out [4]
 ..\vbox(700.50723+0.0)x417.11752, glue set 610.86539fil
 ...\write-{}
 ...\write1{\@writefile{toc}{\protect \addvspace {12bp}}}
-...\write1{\@writefile{toc}{\protect \contentsline {chapter}{Bibliography}{\thepage \ETC.}
+...\write1{\@writefile{toc}{\protect \contentsline {chapter}{Bibliography}{\thepage }{}\protected@file@percent }}
 ...\write1{\@writefile{lof}{\protect \addvspace {10.0pt}}}
 ...\write1{\@writefile{lot}{\protect \addvspace {10.0pt}}}
 ...\glue(\topskip) 12.0
@@ -1747,7 +1747,7 @@ Completed box being shipped out [5]
 ..\vbox(700.50723+0.0)x417.11752, glue set 632.91138fil
 ...\write-{}
 ...\write1{\pp@pagectr{footnote}{3}{\theabspage }{\thepage }}
-...\write1{\@writefile{toc}{\protect \contentsline {chapter}{\protect \numberline \ETC.}
+...\write1{\@writefile{toc}{\protect \contentsline {chapter}{\protect \numberline {Appendix A}附录章节}{\thepage }{}\protected@file@percent }}
 ...\write1{\@writefile{lof}{\protect \addvspace {10.0pt}}}
 ...\write1{\@writefile{lot}{\protect \addvspace {10.0pt}}}
 ...\glue(\topskip) 12.0
@@ -1925,7 +1925,7 @@ Completed box being shipped out [6]
 ..\vbox(700.50723+0.0)x417.11752, glue set 587.68927fil
 ...\write-{}
 ...\write-{}
-...\write1{\@writefile{toc}{\protect \contentsline {chapter}{Acknowledgements}{\thepage \ETC.}
+...\write1{\@writefile{toc}{\protect \contentsline {chapter}{Acknowledgements}{\thepage }{}\protected@file@percent }}
 ...\write1{\@writefile{lof}{\protect \addvspace {10.0pt}}}
 ...\write1{\@writefile{lot}{\protect \addvspace {10.0pt}}}
 ...\glue(\topskip) 12.0

--- a/test/testfiles-crossref/main-bachelor.tlg
+++ b/test/testfiles-crossref/main-bachelor.tlg
@@ -976,7 +976,7 @@ Completed box being shipped out [2]
 ...\write-{}
 ...\write1{\@writefile{toc}{\protect \addvspace {12bp}}}
 ...\write1{\pp@pagectr{footnote}{1}{\theabspage }{\thepage }}
-...\write1{\@writefile{toc}{\protect \contentsline {chapter}{\protect \numberline \ETC.}
+...\write1{\@writefile{toc}{\protect \contentsline {chapter}{\protect \numberline {第一章}简介}{\thepage }{}\protected@file@percent }}
 ...\write1{\@writefile{lof}{\protect \addvspace {10.0pt}}}
 ...\write1{\@writefile{lot}{\protect \addvspace {10.0pt}}}
 ...\glue(\topskip) 12.0
@@ -1058,7 +1058,7 @@ Completed box being shipped out [2]
 ....\penalty 10000
 ....\glue(\parfillskip) 0.0
 ....\glue(\rightskip) 0.0 plus 1.0fil
-...\write1{\@writefile{toc}{\protect \contentsline {section}{\protect \numberline \ETC.}
+...\write1{\@writefile{toc}{\protect \contentsline {section}{\protect \numberline {第一节}一级节标题}{\thepage }{}\protected@file@percent }}
 ...\penalty 10000
 ...\glue 6.02249
 ...\glue(\parskip) 0.0
@@ -1104,7 +1104,7 @@ Completed box being shipped out [2]
 ....\penalty 10000
 ....\glue(\parfillskip) 0.0 plus 1.0fil
 ....\glue(\rightskip) 0.0
-...\write1{\@writefile{toc}{\protect \contentsline {subsection}{\protect \numberline \ETC.}
+...\write1{\@writefile{toc}{\protect \contentsline {subsection}{\protect \numberline {一}二级节标题}{\thepage }{}\protected@file@percent }}
 ...\penalty 10000
 ...\glue 6.02249
 ...\glue(\parskip) 0.0
@@ -1147,7 +1147,7 @@ Completed box being shipped out [2]
 ....\penalty 10000
 ....\glue(\parfillskip) 0.0 plus 1.0fil
 ....\glue(\rightskip) 0.0
-...\write1{\@writefile{toc}{\protect \contentsline {subsubsection}{\protect \numberline \ETC.}
+...\write1{\@writefile{toc}{\protect \contentsline {subsubsection}{\protect \numberline {1}三级节标题}{\thepage }{}\protected@file@percent }}
 ...\penalty 10000
 ...\glue 0.0
 ...\glue(\parskip) 0.0
@@ -1196,7 +1196,7 @@ Completed box being shipped out [2]
 ....\penalty 10000
 ....\glue(\parfillskip) 0.0 plus 1.0fil
 ....\glue(\rightskip) 0.0
-...\write1{\@writefile{toc}{\protect \contentsline {paragraph}{\protect \numberline \ETC.}
+...\write1{\@writefile{toc}{\protect \contentsline {paragraph}{\protect \numberline {（1）}四级节标题}{\thepage }{}\protected@file@percent }}
 ...\penalty 10000
 ...\glue 0.0
 ...\glue(\parskip) 0.0
@@ -1232,7 +1232,7 @@ Completed box being shipped out [2]
 ....\penalty 10000
 ....\glue(\parfillskip) 0.0 plus 1.0fil
 ....\glue(\rightskip) 0.0
-...\write1{\@writefile{toc}{\protect \contentsline {subparagraph}{五级节标题\ETC.}
+...\write1{\@writefile{toc}{\protect \contentsline {subparagraph}{五级节标题}{\thepage }{}\protected@file@percent }}
 ...\penalty 10000
 ...\glue 0.0
 ...\glue(\parskip) 0.0
@@ -1383,7 +1383,7 @@ Completed box being shipped out [3]
 ...\write-{}
 ...\write1{\@writefile{toc}{\protect \addvspace {12bp}}}
 ...\write1{\pp@pagectr{footnote}{2}{\theabspage }{\thepage }}
-...\write1{\@writefile{toc}{\protect \contentsline {chapter}{\protect \numberline \ETC.}
+...\write1{\@writefile{toc}{\protect \contentsline {chapter}{\protect \numberline {第二章}浮动体}{\thepage }{}\protected@file@percent }}
 ...\write1{\@writefile{lof}{\protect \addvspace {10.0pt}}}
 ...\write1{\@writefile{lot}{\protect \addvspace {10.0pt}}}
 ...\glue(\topskip) 12.0
@@ -1557,8 +1557,7 @@ Completed box being shipped out [4]
 ..\vbox(700.50723+0.0)x417.11752, glue set 610.39568fil
 ...\write-{}
 ...\write1{\@writefile{toc}{\protect \addvspace {12bp}}}
-...\write1{\@writefile{toc}{\protect \contentsline {chapter}{参考文献}{\thepage \ET
-C.}
+...\write1{\@writefile{toc}{\protect \contentsline {chapter}{参考文献}{\thepage }{}\protected@file@percent }}
 ...\write1{\@writefile{lof}{\protect \addvspace {10.0pt}}}
 ...\write1{\@writefile{lot}{\protect \addvspace {10.0pt}}}
 ...\glue(\topskip) 12.0
@@ -1794,7 +1793,7 @@ Completed box being shipped out [5]
 ..\vbox(700.50723+0.0)x417.11752, glue set 633.65005fil
 ...\write-{}
 ...\write1{\pp@pagectr{footnote}{3}{\theabspage }{\thepage }}
-...\write1{\@writefile{toc}{\protect \contentsline {chapter}{\protect \numberline \ETC.}
+...\write1{\@writefile{toc}{\protect \contentsline {chapter}{\protect \numberline {附录 A}附录章节}{\thepage }{}\protected@file@percent }}
 ...\write1{\@writefile{lof}{\protect \addvspace {10.0pt}}}
 ...\write1{\@writefile{lot}{\protect \addvspace {10.0pt}}}
 ...\glue(\topskip) 12.0
@@ -1976,8 +1975,7 @@ Completed box being shipped out [6]
 ..\vbox(700.50723+0.0)x417.11752, glue set 587.5086fil
 ...\write-{}
 ...\write-{}
-...\write1{\@writefile{toc}{\protect \contentsline {chapter}{致谢}{\thepage }{\ET
-C.}
+...\write1{\@writefile{toc}{\protect \contentsline {chapter}{致谢}{\thepage }{}\protected@file@percent }}
 ...\write1{\@writefile{lof}{\protect \addvspace {10.0pt}}}
 ...\write1{\@writefile{lot}{\protect \addvspace {10.0pt}}}
 ...\glue(\topskip) 12.0

--- a/test/testfiles-crossref/main-english.tlg
+++ b/test/testfiles-crossref/main-english.tlg
@@ -1080,7 +1080,7 @@ Completed box being shipped out [1]
 ..\vbox(700.50723+0.0)x417.11752, glue set 320.01578fil
 ...\write-{}
 ...\write1{\pp@pagectr{footnote}{1}{\theabspage }{\thepage }}
-...\write1{\@writefile{toc}{\protect \contentsline {chapter}{\protect \numberline \ETC.}
+...\write1{\@writefile{toc}{\protect \contentsline {chapter}{\protect \numberline {Chapter 1}简介}{\thepage }{}\protected@file@percent }}
 ...\marks1{Chapter 1\hskip 1em\relax \protect \ustc@spacetitle  {简介}}
 ...\marks2{\prg_do_nothing: }
 ...\mark{{Chapter 1\hskip 1em\relax \protect \ustc@spacetitle  {简介}}{}}
@@ -1157,7 +1157,7 @@ Completed box being shipped out [1]
 ....\penalty 10000
 ....\glue(\parfillskip) 0.0 plus 1.0fil
 ....\glue(\rightskip) 0.0
-...\write1{\@writefile{toc}{\protect \contentsline {section}{\protect \numberline \ETC.}
+...\write1{\@writefile{toc}{\protect \contentsline {section}{\protect \numberline {1.1}一级节标题}{\thepage }{}\protected@file@percent }}
 ...\penalty 10000
 ...\glue 6.02249
 ...\glue(\parskip) 0.0
@@ -1197,7 +1197,7 @@ Completed box being shipped out [1]
 ....\penalty 10000
 ....\glue(\parfillskip) 0.0 plus 1.0fil
 ....\glue(\rightskip) 0.0
-...\write1{\@writefile{toc}{\protect \contentsline {subsection}{\protect \numberline \ETC.}
+...\write1{\@writefile{toc}{\protect \contentsline {subsection}{\protect \numberline {1.1.1}二级节标题}{\thepage }{}\protected@file@percent }}
 ...\penalty 10000
 ...\glue 6.02249
 ...\glue(\parskip) 0.0
@@ -1240,7 +1240,7 @@ Completed box being shipped out [1]
 ....\penalty 10000
 ....\glue(\parfillskip) 0.0 plus 1.0fil
 ....\glue(\rightskip) 0.0
-...\write1{\@writefile{toc}{\protect \contentsline {subsubsection}{\protect \numberline \ETC.}
+...\write1{\@writefile{toc}{\protect \contentsline {subsubsection}{\protect \numberline {1}三级节标题}{\thepage }{}\protected@file@percent }}
 ...\penalty 10000
 ...\glue 0.0
 ...\glue(\parskip) 0.0
@@ -1290,7 +1290,7 @@ Completed box being shipped out [1]
 ....\penalty 10000
 ....\glue(\parfillskip) 0.0 plus 1.0fil
 ....\glue(\rightskip) 0.0
-...\write1{\@writefile{toc}{\protect \contentsline {paragraph}{\protect \numberline \ETC.}
+...\write1{\@writefile{toc}{\protect \contentsline {paragraph}{\protect \numberline {（1）}四级节标题}{\thepage }{}\protected@file@percent }}
 ...\penalty 10000
 ...\glue 0.0
 ...\glue(\parskip) 0.0
@@ -1330,7 +1330,7 @@ Completed box being shipped out [1]
 ....\penalty 10000
 ....\glue(\parfillskip) 0.0 plus 1.0fil
 ....\glue(\rightskip) 0.0
-...\write1{\@writefile{toc}{\protect \contentsline {subparagraph}{\protect \numberline \ETC.}
+...\write1{\@writefile{toc}{\protect \contentsline {subparagraph}{\protect \numberline {\relax {\protect \symbol  {\numexpr \c@subparagraph  + "245F\relax }}}五级节标题}{\thepage }{}\protected@file@percent }}
 ...\penalty 10000
 ...\glue 0.0
 ...\glue(\parskip) 0.0
@@ -1511,7 +1511,7 @@ Completed box being shipped out [2]
 ..\vbox(700.50723+0.0)x417.11752, glue set 648.66777fil
 ...\write-{}
 ...\write1{\pp@pagectr{footnote}{2}{\theabspage }{\thepage }}
-...\write1{\@writefile{toc}{\protect \contentsline {chapter}{\protect \numberline \ETC.}
+...\write1{\@writefile{toc}{\protect \contentsline {chapter}{\protect \numberline {Chapter 2}浮动体}{\thepage }{}\protected@file@percent }}
 ...\marks1{Chapter 2\hskip 1em\relax \protect \ustc@spacetitle  {浮动体}}
 ...\marks2{\prg_do_nothing: }
 ...\mark{{Chapter 2\hskip 1em\relax \protect \ustc@spacetitle  {浮动体}}{}}
@@ -1659,7 +1659,7 @@ Completed box being shipped out [3]
 ..\vbox(700.50723+0.0)x417.11752, glue set 615.5288fil
 ...\write-{}
 ...\write-{}
-...\write1{\@writefile{toc}{\protect \contentsline {chapter}{Bibliography}{\thepage \ETC.}
+...\write1{\@writefile{toc}{\protect \contentsline {chapter}{Bibliography}{\thepage }{}\protected@file@percent }}
 ...\marks1{\protect \ustc@spacetitle  {Bibliography}}
 ...\marks2{\prg_do_nothing: }
 ...\mark{{\protect \ustc@spacetitle  {Bibliography}}{}}
@@ -1877,10 +1877,10 @@ Completed box being shipped out [4]
 ..\vbox(700.50723+0.0)x417.11752, glue set 633.12012fil
 ...\write-{}
 ...\write1{\pp@pagectr{footnote}{3}{\theabspage }{\thepage }}
-...\write1{\@writefile{toc}{\protect \contentsline {chapter}{\protect \numberline \ETC.}
+...\write1{\@writefile{toc}{\protect \contentsline {chapter}{\protect \numberline {Appendix A}附录章节}{\thepage }{}\protected@file@percent }}
 ...\marks1{Appendix A\hskip 1em\relax \protect \ustc@spacetitle  {附录章节}}
 ...\marks2{\prg_do_nothing: }
-...\mark{{Appendix A\hskip 1em\relax \protect \ustc@spacetitle  {附录章节}\ETC.}
+...\mark{{Appendix A\hskip 1em\relax \protect \ustc@spacetitle  {附录章节}}{}}
 ...\write1{\@writefile{lof}{\protect \addvspace {10.0pt}}}
 ...\write1{\@writefile{lot}{\protect \addvspace {10.0pt}}}
 ...\glue(\topskip) 12.0
@@ -2029,7 +2029,7 @@ Completed box being shipped out [5]
 ..\glue(\lineskip) 0.0
 ..\vbox(700.50723+0.0)x417.11752, glue set 633.75043fil
 ...\write-{}
-...\write1{\@writefile{toc}{\protect \contentsline {chapter}{Acknowledgements}{\thepage \ETC.}
+...\write1{\@writefile{toc}{\protect \contentsline {chapter}{Acknowledgements}{\thepage }{}\protected@file@percent }}
 ...\marks1{\protect \ustc@spacetitle  {Acknowledgements}}
 ...\marks2{\prg_do_nothing: }
 ...\mark{{\protect \ustc@spacetitle  {Acknowledgements}}{}}
@@ -2171,7 +2171,7 @@ Completed box being shipped out [6]
 ..\glue(\lineskip) 0.0
 ..\vbox(700.50723+0.0)x417.11752, glue set 636.81354fil
 ...\write-{}
-...\write1{\@writefile{toc}{\protect \contentsline {chapter}{Publications}{\thepage \ETC.}
+...\write1{\@writefile{toc}{\protect \contentsline {chapter}{Publications}{\thepage }{}\protected@file@percent }}
 ...\marks1{\protect \ustc@spacetitle  {Publications}}
 ...\marks2{\prg_do_nothing: }
 ...\mark{{\protect \ustc@spacetitle  {Publications}}{}}

--- a/test/testfiles-crossref/main-lof.tlg
+++ b/test/testfiles-crossref/main-lof.tlg
@@ -553,7 +553,7 @@ Completed box being shipped out [1]
 ..\vbox(700.50723+0.0)x417.11752, glue set 529.77524fil
 ...\write-{}
 ...\write1{\pp@pagectr{footnote}{1}{\theabspage }{\thepage }}
-...\write1{\@writefile{toc}{\protect \contentsline {chapter}{\protect \numberline \ETC.}
+...\write1{\@writefile{toc}{\protect \contentsline {chapter}{\protect \numberline {第1章}Foo}{\thepage }{}\protected@file@percent }}
 ...\marks1{第1章\hskip 1em\relax \protect \ustc@spacetitle  {Foo}}
 ...\marks2{\prg_do_nothing: }
 ...\mark{{第1章\hskip 1em\relax \protect \ustc@spacetitle  {Foo}}{}}
@@ -590,7 +590,7 @@ Completed box being shipped out [1]
 ...\vbox(25.74614+0.0)x417.11752
 ....\special{color push  Black}
 ....\vbox(25.74614+0.0)x417.11752
-.....\write1{\@writefile{lof}{\protect \contentsline {figure}{\protect \numberline \ETC.}
+.....\write1{\@writefile{lof}{\protect \contentsline {figure}{\protect \numberline {1.1}{\ignorespaces Figure foo\relax }}{\thepage }{}\protected@file@percent }}
 .....\special{color push  Black}
 .....\rule(0.0+0.0)x*
 .....\glue 6.02249
@@ -644,7 +644,7 @@ Completed box being shipped out [1]
 ...\vbox(25.74614+0.0)x417.11752
 ....\special{color push  Black}
 ....\vbox(25.74614+0.0)x417.11752
-.....\write1{\@writefile{lof}{\protect \contentsline {figure}{\protect \numberline \ETC.}
+.....\write1{\@writefile{lof}{\protect \contentsline {figure}{\protect \numberline {1.2}{\ignorespaces Figure A long long long long long long long long long caption\relax }}{\thepage }{}\protected@file@percent }}
 .....\special{color push  Black}
 .....\rule(0.0+0.0)x*
 .....\glue 6.02249
@@ -718,7 +718,7 @@ Completed box being shipped out [1]
 ...\vbox(25.74614+0.0)x417.11752
 ....\special{color push  Black}
 ....\vbox(25.74614+0.0)x417.11752
-.....\write1{\@writefile{lof}{\protect \contentsline {figure}{\protect \numberline \ETC.}
+.....\write1{\@writefile{lof}{\protect \contentsline {figure}{\protect \numberline {1.3}{\ignorespaces Figure foo\relax }}{\thepage }{}\protected@file@percent }}
 .....\special{color push  Black}
 .....\rule(0.0+0.0)x*
 .....\glue 6.02249
@@ -868,7 +868,7 @@ Completed box being shipped out [2]
 ..\vbox(700.50723+0.0)x417.11752, glue set 529.77524fil
 ...\write-{}
 ...\write1{\pp@pagectr{footnote}{2}{\theabspage }{\thepage }}
-...\write1{\@writefile{toc}{\protect \contentsline {chapter}{\protect \numberline \ETC.}
+...\write1{\@writefile{toc}{\protect \contentsline {chapter}{\protect \numberline {第2章}Bar}{\thepage }{}\protected@file@percent }}
 ...\marks1{第2章\hskip 1em\relax \protect \ustc@spacetitle  {Bar}}
 ...\marks2{\prg_do_nothing: }
 ...\mark{{第2章\hskip 1em\relax \protect \ustc@spacetitle  {Bar}}{}}
@@ -905,7 +905,7 @@ Completed box being shipped out [2]
 ...\vbox(25.74614+0.0)x417.11752
 ....\special{color push  Black}
 ....\vbox(25.74614+0.0)x417.11752
-.....\write1{\@writefile{lof}{\protect \contentsline {figure}{\protect \numberline \ETC.}
+.....\write1{\@writefile{lof}{\protect \contentsline {figure}{\protect \numberline {2.1}{\ignorespaces Figure foo\relax }}{\thepage }{}\protected@file@percent }}
 .....\special{color push  Black}
 .....\rule(0.0+0.0)x*
 .....\glue 6.02249
@@ -959,7 +959,7 @@ Completed box being shipped out [2]
 ...\vbox(25.74614+0.0)x417.11752
 ....\special{color push  Black}
 ....\vbox(25.74614+0.0)x417.11752
-.....\write1{\@writefile{lof}{\protect \contentsline {figure}{\protect \numberline \ETC.}
+.....\write1{\@writefile{lof}{\protect \contentsline {figure}{\protect \numberline {2.2}{\ignorespaces Figure bar\relax }}{\thepage }{}\protected@file@percent }}
 .....\special{color push  Black}
 .....\rule(0.0+0.0)x*
 .....\glue 6.02249
@@ -1013,7 +1013,7 @@ Completed box being shipped out [2]
 ...\vbox(25.74614+0.0)x417.11752
 ....\special{color push  Black}
 ....\vbox(25.74614+0.0)x417.11752
-.....\write1{\@writefile{lof}{\protect \contentsline {figure}{\protect \numberline \ETC.}
+.....\write1{\@writefile{lof}{\protect \contentsline {figure}{\protect \numberline {2.3}{\ignorespaces Figure foo\relax }}{\thepage }{}\protected@file@percent }}
 .....\special{color push  Black}
 .....\rule(0.0+0.0)x*
 .....\glue 6.02249

--- a/test/testfiles-crossref/main-lot.tlg
+++ b/test/testfiles-crossref/main-lot.tlg
@@ -533,7 +533,7 @@ Completed box being shipped out [1]
 ..\vbox(700.50723+0.0)x417.11752, glue set 547.84077fil
 ...\write-{}
 ...\write1{\pp@pagectr{footnote}{1}{\theabspage }{\thepage }}
-...\write1{\@writefile{toc}{\protect \contentsline {chapter}{\protect \numberline \ETC.}
+...\write1{\@writefile{toc}{\protect \contentsline {chapter}{\protect \numberline {第1章}Foo}{\thepage }{}\protected@file@percent }}
 ...\marks1{第1章\hskip 1em\relax \protect \ustc@spacetitle  {Foo}}
 ...\marks2{\prg_do_nothing: }
 ...\mark{{第1章\hskip 1em\relax \protect \ustc@spacetitle  {Foo}}{}}
@@ -570,7 +570,7 @@ Completed box being shipped out [1]
 ...\vbox(19.72365+0.0)x417.11752
 ....\special{color push  Black}
 ....\vbox(19.72365+0.0)x417.11752
-.....\write1{\@writefile{lot}{\protect \contentsline {table}{\protect \numberline \ETC.}
+.....\write1{\@writefile{lot}{\protect \contentsline {table}{\protect \numberline {1.1}{\ignorespaces Table foo\relax }}{\thepage }{}\protected@file@percent }}
 .....\special{color push  Black}
 .....\glue 0.0
 .....\glue(\parskip) 0.0
@@ -624,7 +624,7 @@ Completed box being shipped out [1]
 ...\vbox(19.72365+0.0)x417.11752
 ....\special{color push  Black}
 ....\vbox(19.72365+0.0)x417.11752
-.....\write1{\@writefile{lot}{\protect \contentsline {table}{\protect \numberline \ETC.}
+.....\write1{\@writefile{lot}{\protect \contentsline {table}{\protect \numberline {1.2}{\ignorespaces Table bar\relax }}{\thepage }{}\protected@file@percent }}
 .....\special{color push  Black}
 .....\glue 0.0
 .....\glue(\parskip) 0.0
@@ -678,7 +678,7 @@ Completed box being shipped out [1]
 ...\vbox(19.72365+0.0)x417.11752
 ....\special{color push  Black}
 ....\vbox(19.72365+0.0)x417.11752
-.....\write1{\@writefile{lot}{\protect \contentsline {table}{\protect \numberline \ETC.}
+.....\write1{\@writefile{lot}{\protect \contentsline {table}{\protect \numberline {1.3}{\ignorespaces Table foo\relax }}{\thepage }{}\protected@file@percent }}
 .....\special{color push  Black}
 .....\glue 0.0
 .....\glue(\parskip) 0.0
@@ -828,7 +828,7 @@ Completed box being shipped out [2]
 ..\vbox(700.50723+0.0)x417.11752, glue set 547.84077fil
 ...\write-{}
 ...\write1{\pp@pagectr{footnote}{2}{\theabspage }{\thepage }}
-...\write1{\@writefile{toc}{\protect \contentsline {chapter}{\protect \numberline \ETC.}
+...\write1{\@writefile{toc}{\protect \contentsline {chapter}{\protect \numberline {第2章}Bar}{\thepage }{}\protected@file@percent }}
 ...\marks1{第2章\hskip 1em\relax \protect \ustc@spacetitle  {Bar}}
 ...\marks2{\prg_do_nothing: }
 ...\mark{{第2章\hskip 1em\relax \protect \ustc@spacetitle  {Bar}}{}}
@@ -865,7 +865,7 @@ Completed box being shipped out [2]
 ...\vbox(19.72365+0.0)x417.11752
 ....\special{color push  Black}
 ....\vbox(19.72365+0.0)x417.11752
-.....\write1{\@writefile{lot}{\protect \contentsline {table}{\protect \numberline \ETC.}
+.....\write1{\@writefile{lot}{\protect \contentsline {table}{\protect \numberline {2.1}{\ignorespaces Table foo\relax }}{\thepage }{}\protected@file@percent }}
 .....\special{color push  Black}
 .....\glue 0.0
 .....\glue(\parskip) 0.0
@@ -919,7 +919,7 @@ Completed box being shipped out [2]
 ...\vbox(19.72365+0.0)x417.11752
 ....\special{color push  Black}
 ....\vbox(19.72365+0.0)x417.11752
-.....\write1{\@writefile{lot}{\protect \contentsline {table}{\protect \numberline \ETC.}
+.....\write1{\@writefile{lot}{\protect \contentsline {table}{\protect \numberline {2.2}{\ignorespaces Table bar\relax }}{\thepage }{}\protected@file@percent }}
 .....\special{color push  Black}
 .....\glue 0.0
 .....\glue(\parskip) 0.0
@@ -973,7 +973,7 @@ Completed box being shipped out [2]
 ...\vbox(19.72365+0.0)x417.11752
 ....\special{color push  Black}
 ....\vbox(19.72365+0.0)x417.11752
-.....\write1{\@writefile{lot}{\protect \contentsline {table}{\protect \numberline \ETC.}
+.....\write1{\@writefile{lot}{\protect \contentsline {table}{\protect \numberline {2.3}{\ignorespaces Table foo\relax }}{\thepage }{}\protected@file@percent }}
 .....\special{color push  Black}
 .....\glue 0.0
 .....\glue(\parskip) 0.0

--- a/test/testfiles-crossref/main.tlg
+++ b/test/testfiles-crossref/main.tlg
@@ -1148,7 +1148,7 @@ Completed box being shipped out [1]
 ..\vbox(700.50723+0.0)x417.11752, glue set 320.7384fil
 ...\write-{}
 ...\write1{\pp@pagectr{footnote}{1}{\theabspage }{\thepage }}
-...\write1{\@writefile{toc}{\protect \contentsline {chapter}{\protect \numberline \ETC.}
+...\write1{\@writefile{toc}{\protect \contentsline {chapter}{\protect \numberline {第1章}简介}{\thepage }{}\protected@file@percent }}
 ...\marks1{第1章\hskip 1em\relax \protect \ustc@spacetitle  {简介}}
 ...\marks2{\prg_do_nothing: }
 ...\mark{{第1章\hskip 1em\relax \protect \ustc@spacetitle  {简介}}{}}
@@ -1227,7 +1227,7 @@ Completed box being shipped out [1]
 ....\penalty 10000
 ....\glue(\parfillskip) 0.0 plus 1.0fil
 ....\glue(\rightskip) 0.0
-...\write1{\@writefile{toc}{\protect \contentsline {section}{\protect \numberline \ETC.}
+...\write1{\@writefile{toc}{\protect \contentsline {section}{\protect \numberline {1.1}一级节标题}{\thepage }{}\protected@file@percent }}
 ...\penalty 10000
 ...\glue 6.02249
 ...\glue(\parskip) 0.0
@@ -1267,7 +1267,7 @@ Completed box being shipped out [1]
 ....\penalty 10000
 ....\glue(\parfillskip) 0.0 plus 1.0fil
 ....\glue(\rightskip) 0.0
-...\write1{\@writefile{toc}{\protect \contentsline {subsection}{\protect \numberline \ETC.}
+...\write1{\@writefile{toc}{\protect \contentsline {subsection}{\protect \numberline {1.1.1}二级节标题}{\thepage }{}\protected@file@percent }}
 ...\penalty 10000
 ...\glue 6.02249
 ...\glue(\parskip) 0.0
@@ -1310,7 +1310,7 @@ Completed box being shipped out [1]
 ....\penalty 10000
 ....\glue(\parfillskip) 0.0 plus 1.0fil
 ....\glue(\rightskip) 0.0
-...\write1{\@writefile{toc}{\protect \contentsline {subsubsection}{\protect \numberline \ETC.}
+...\write1{\@writefile{toc}{\protect \contentsline {subsubsection}{\protect \numberline {1}三级节标题}{\thepage }{}\protected@file@percent }}
 ...\penalty 10000
 ...\glue 0.0
 ...\glue(\parskip) 0.0
@@ -1360,7 +1360,7 @@ Completed box being shipped out [1]
 ....\penalty 10000
 ....\glue(\parfillskip) 0.0 plus 1.0fil
 ....\glue(\rightskip) 0.0
-...\write1{\@writefile{toc}{\protect \contentsline {paragraph}{\protect \numberline \ETC.}
+...\write1{\@writefile{toc}{\protect \contentsline {paragraph}{\protect \numberline {（1）}四级节标题}{\thepage }{}\protected@file@percent }}
 ...\penalty 10000
 ...\glue 0.0
 ...\glue(\parskip) 0.0
@@ -1400,7 +1400,7 @@ Completed box being shipped out [1]
 ....\penalty 10000
 ....\glue(\parfillskip) 0.0 plus 1.0fil
 ....\glue(\rightskip) 0.0
-...\write1{\@writefile{toc}{\protect \contentsline {subparagraph}{\protect \numberline \ETC.}
+...\write1{\@writefile{toc}{\protect \contentsline {subparagraph}{\protect \numberline {\relax {\protect \symbol  {\numexpr \c@subparagraph  + "245F\relax }}}五级节标题}{\thepage }{}\protected@file@percent }}
 ...\penalty 10000
 ...\glue 0.0
 ...\glue(\parskip) 0.0
@@ -1612,7 +1612,7 @@ Completed box being shipped out [2]
 ..\vbox(700.50723+0.0)x417.11752, glue set 649.278fil
 ...\write-{}
 ...\write1{\pp@pagectr{footnote}{2}{\theabspage }{\thepage }}
-...\write1{\@writefile{toc}{\protect \contentsline {chapter}{\protect \numberline \ETC.}
+...\write1{\@writefile{toc}{\protect \contentsline {chapter}{\protect \numberline {第2章}浮动体}{\thepage }{}\protected@file@percent }}
 ...\marks1{第2章\hskip 1em\relax \protect \ustc@spacetitle  {浮动体}}
 ...\marks2{\prg_do_nothing: }
 ...\mark{{第2章\hskip 1em\relax \protect \ustc@spacetitle  {浮动体}}{}}
@@ -1768,8 +1768,7 @@ Completed box being shipped out [3]
 ..\vbox(700.50723+0.0)x417.11752, glue set 615.6412fil
 ...\write-{}
 ...\write-{}
-...\write1{\@writefile{toc}{\protect \contentsline {chapter}{参考文献}{\thepage \ET
-C.}
+...\write1{\@writefile{toc}{\protect \contentsline {chapter}{参考文献}{\thepage }{}\protected@file@percent }}
 ...\marks1{\protect \ustc@spacetitle  {参考文献}}
 ...\marks2{\prg_do_nothing: }
 ...\mark{{\protect \ustc@spacetitle  {参考文献}}{}}
@@ -1995,10 +1994,10 @@ Completed box being shipped out [4]
 ..\vbox(700.50723+0.0)x417.11752, glue set 633.84274fil
 ...\write-{}
 ...\write1{\pp@pagectr{footnote}{3}{\theabspage }{\thepage }}
-...\write1{\@writefile{toc}{\protect \contentsline {chapter}{\protect \numberline \ETC.}
+...\write1{\@writefile{toc}{\protect \contentsline {chapter}{\protect \numberline {附录 A}附录章节}{\thepage }{}\protected@file@percent }}
 ...\marks1{附录 A\hskip 1em\relax \protect \ustc@spacetitle  {附录章节}}
 ...\marks2{\prg_do_nothing: }
-...\mark{{附录 A\hskip 1em\relax \protect \ustc@spacetitle  {附录章节}}{\ETC.}
+...\mark{{附录 A\hskip 1em\relax \protect \ustc@spacetitle  {附录章节}}{}}
 ...\write1{\@writefile{lof}{\protect \addvspace {10.0pt}}}
 ...\write1{\@writefile{lot}{\protect \addvspace {10.0pt}}}
 ...\glue(\topskip) 12.0
@@ -2153,8 +2152,7 @@ Completed box being shipped out [5]
 ..\glue(\lineskip) 0.0
 ..\vbox(700.50723+0.0)x417.11752, glue set 633.78255fil
 ...\write-{}
-...\write1{\@writefile{toc}{\protect \contentsline {chapter}{致谢}{\thepage }{\ET
-C.}
+...\write1{\@writefile{toc}{\protect \contentsline {chapter}{致谢}{\thepage }{}\protected@file@percent }}
 ...\marks1{\protect \ustc@spacetitle  {致谢}}
 ...\marks2{\prg_do_nothing: }
 ...\mark{{\protect \ustc@spacetitle  {致谢}}{}}
@@ -2334,10 +2332,10 @@ Completed box being shipped out [6]
 ..\glue(\lineskip) 0.0
 ..\vbox(700.50723+0.0)x417.11752, glue set 633.4413fil
 ...\write-{}
-...\write1{\@writefile{toc}{\protect \contentsline {chapter}{在读期间发表的\ETC.}
-...\marks1{\protect \ustc@spacetitle  {在读期间发表的学术论文与取得\ETC.}
+...\write1{\@writefile{toc}{\protect \contentsline {chapter}{在读期间发表的学术论文与取得的研究成果}{\thepage }{}\protected@file@percent }}
+...\marks1{\protect \ustc@spacetitle  {在读期间发表的学术论文与取得的研究成果}}
 ...\marks2{\prg_do_nothing: }
-...\mark{{\protect \ustc@spacetitle  {在读期间发表的学术论文与取得\ETC.}
+...\mark{{\protect \ustc@spacetitle  {在读期间发表的学术论文与取得的研究成果}}{}}
 ...\write1{\@writefile{lof}{\protect \addvspace {10.0pt}}}
 ...\write1{\@writefile{lot}{\protect \addvspace {10.0pt}}}
 ...\glue(\topskip) 12.0

--- a/test/testfiles-nomencl/package-nomencl.tlg
+++ b/test/testfiles-nomencl/package-nomencl.tlg
@@ -425,7 +425,7 @@ Completed box being shipped out [1]
 ..\vbox(700.50723+0.0)x417.11752, glue set 635.16356fil
 ...\write-{}
 ...\write1{\pp@pagectr{footnote}{1}{\theabspage }{\thepage }}
-...\write1{\@writefile{toc}{\protect \contentsline {chapter}{\protect \numberline \ETC.}
+...\write1{\@writefile{toc}{\protect \contentsline {chapter}{\protect \numberline {第1章}Main matter}{\thepage }{}\protected@file@percent }}
 ...\marks1{第1章\hskip 1em\relax \protect \ustc@spacetitle  {Main matter}}
 ...\marks2{\prg_do_nothing: }
 ...\mark{{第1章\hskip 1em\relax \protect \ustc@spacetitle  {Main matter}}{}}
@@ -466,17 +466,17 @@ Completed box being shipped out [1]
 ....\glue 3.01125 plus 1.50562 minus 1.00374
 ....\TU/texgyretermes(0)/m/n/12.045 ipsum.
 ....\glue 4.01498 plus 4.51685 minus 0.33458
-....\write3{\nomenclatureentry{a$a$@[{$a$}]\begingroup The number of angels per u\ETC.}
+....\write3{\nomenclatureentry{a$a$@[{$a$}]\begingroup The number of angels per unit area\protect \nomeqref {1.0}|nompageref}{\thepage }}
 ....\penalty 10000
 ....\glue 0.0
-....\write3{\nomenclatureentry{a$N$@[{$N$}]\begingroup The number of angels per n\ETC.}
+....\write3{\nomenclatureentry{a$N$@[{$N$}]\begingroup The number of angels per needle point\protect \nomeqref {1.0}|nompageref}{\thepage }}
 ....\glue 4.01498 plus 4.51685 minus 0.33458
-....\write3{\nomenclatureentry{a$A$@[{$A$}]\begingroup The area of the needle poi\ETC.}
+....\write3{\nomenclatureentry{a$A$@[{$A$}]\begingroup The area of the needle point\protect \nomeqref {1.0}|nompageref}{\thepage }}
 ....\penalty 10000
 ....\glue 0.0
-....\write3{\nomenclatureentry{a$\sigma$@[{$\sigma$}]\begingroup The total mass o\ETC.}
+....\write3{\nomenclatureentry{a$\sigma$@[{$\sigma$}]\begingroup The total mass of angels per unit area\protect \nomeqref {1.0}|nompageref}{\thepage }}
 ....\glue 4.01498 plus 4.51685 minus 0.33458
-....\write3{\nomenclatureentry{a$m$@[{$m$}]\begingroup The mass of one angel\protect \ETC.}
+....\write3{\nomenclatureentry{a$m$@[{$m$}]\begingroup The mass of one angel\protect \nomeqref {1.0}|nompageref}{\thepage }}
 ....\penalty 10000
 ....\penalty 10000
 ....\glue(\parfillskip) 0.0 plus 1.0fil


### PR DESCRIPTION
Github actions can fail for the following reasons.

1.Install required pkgs failed

> ![image](https://user-images.githubusercontent.com/34184767/231928073-0d7146a0-cceb-4b36-98ef-750411887be0.png)
 
The `tlmgr` in `tunathu/thuthesis-test-env` requires a forced update.

2.l3build check failed

Upgrading `tlmgr` first and then installing caused some pkgs to change and failed in l3build check.

After `make save` locally, the regenerated files passed `make test`, and passed [Github actions in my repo](https://github.com/ericbrownz/ustcthesis/actions/runs/4695681079).