### PR TITLE
Fix word count warning

### DIFF
--- a/ustcsetup.tex
+++ b/ustcsetup.tex
@@ -86,8 +86,10 @@
 
 % 用于写文档的命令
 \DeclareRobustCommand\cs[1]{\texttt{\char`\\#1}}
+%TC:ignore
 \DeclareRobustCommand\env{\texttt}
 \DeclareRobustCommand\pkg{\textsf}
+%TC:endignore
 \DeclareRobustCommand\file{\nolinkurl}
 
 % hyperref 宏包在最后调用


### PR DESCRIPTION
在texpage/overleaf 平台字数统计功能有warning，排查了一下是由于这两个命令引起的，可以忽略
![image](https://github.com/ustctug/ustcthesis/assets/59607623/37e9629b-21da-422c-9e67-898e42dc2d03)

