### PR TITLE
Fix make install for doc file name

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -41,7 +41,7 @@ install : cls doc
 	mkdir -p $(TEXMF)/{doc,source,tex}/latex/$(NAME)
 	mkdir -p $(TEXMF)/bibtex/bst/$(NAME)
 	cp $(BSTFILES) $(TEXMF)/bibtex/bst/$(NAME)
-	cp $(NAME).pdf $(TEXMF)/doc/latex/$(NAME)
+	cp $(NAME)-doc.pdf $(TEXMF)/doc/latex/$(NAME)/$(NAME).pdf
 	cp $(CLSFILES) $(TEXMF)/tex/latex/$(NAME)
 
 zip : main doc


### PR DESCRIPTION
修正了 Makefile 以避免 `make install` 时发生以下报错：

```
cp $(NAME).pdf $(TEXMF)/doc/latex/$(NAME)
cp: cannot stat 'ustcthesis.pdf': No such file or directory
make: *** [Makefile:44: install] Error 1
```