### PR TITLE
Fix Chinese keywords in ustcthesis.cls

### DIFF
--- a/ustcthesis.cls
+++ b/ustcthesis.cls
@@ -2471,9 +2471,9 @@
   \noindent
   \textbf{关键词：}%
   \ifustc@degree@graduate
-    \ustc@clist@use{\ustc@keywords@en}{, }%
+    \ustc@clist@use{\ustc@keywords}{, }%
   \else
-    \ustc@clist@use{\ustc@keywords@en}{; }%
+    \ustc@clist@use{\ustc@keywords}{; }%
   \fi
   \par
   \ustc@reset@main@language


### PR DESCRIPTION
新版本的中文关键词没了，变成了英文，可以按这个修复。

另外现在 headsep = 1pt 好像不太美观，也许可以建议同学们自己改一下。