### PR TITLE
fix: resolve possible page number issue on blank page between undergraduate thesis abstract and table of contents

### DIFF
--- a/ustcthesis.cls
+++ b/ustcthesis.cls
@@ -1613,7 +1613,14 @@
 \fancypagestyle{blank}{%
   \fancyhf{}%
   \renewcommand\headrulewidth{0pt}%
-  \fancyfoot[C]{\ustc@hf@font\thepage}%
+  \ifustc@degree@bachelor
+    % 本科生frontmatter时空白页不显示页码
+    \if@mainmatter
+      \fancyfoot[C]{\ustc@hf@font\thepage}%
+    \fi
+  \else
+    \fancyfoot[C]{\ustc@hf@font\thepage}%
+  \fi
 }
 
 \newif\ifustc@title@page


### PR DESCRIPTION
本科生毕业论文的摘要如果是奇数页（比如出现中文一页，英文两页这种情况），会在目录和摘要之间再加入一面空白页（因为目录会另开页），而这个空白页会有罗马字母的页码（本科生摘要部分不应该有罗马页码），这个PR主要是修复这个小问题