### PR TITLE
本科生 2026-04-24 格式式样更新

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - 本科生的正文行距改为 20 磅（同步教务处 2026-04-24 格式式样更新，[#501](https://github.com/ustctug/ustcthesis/issues/501)）。
 - 更新本科生的目录格式：章标题加粗，去掉空行，调整缩进（同步教务处 2026-04-24 格式式样更新，[#505](https://github.com/ustctug/ustcthesis/issues/505)）。
+- 修改本科生目录中“参考文献”、“致谢”的空格（同步教务处 2026-04-24 格式式样更新）。
 
 ## [4.0.0-beta.11] - 2026-04-06
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- 本科生的正文行距改为 20 磅（同步教务处 2026-04-24 格式式样更新，[#501](https://github.com/ustctug/ustcthesis/issues/501)）。
+
 ## [4.0.0-beta.11] - 2026-04-06
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - 本科生的正文行距改为 20 磅（同步教务处 2026-04-24 格式式样更新，[#501](https://github.com/ustctug/ustcthesis/issues/501)）。
 - 更新本科生的目录格式：章标题加粗，去掉空行，调整缩进（同步教务处 2026-04-24 格式式样更新，[#505](https://github.com/ustctug/ustcthesis/issues/505)）。
 - 修改本科生目录中“参考文献”、“致谢”的空格（同步教务处 2026-04-24 格式式样更新）。
+- 本科生的节标题改为左对齐（同步教务处 2026-04-24 格式式样更新，[#504](https://github.com/ustctug/ustcthesis/issues/504)）。
 
 ## [4.0.0-beta.11] - 2026-04-06
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - 本科生的正文行距改为 20 磅（同步教务处 2026-04-24 格式式样更新，[#501](https://github.com/ustctug/ustcthesis/issues/501)）。
+- 更新本科生的目录格式：章标题加粗，去掉空行，调整缩进（同步教务处 2026-04-24 格式式样更新，[#505](https://github.com/ustctug/ustcthesis/issues/505)）。
 
 ## [4.0.0-beta.11] - 2026-04-06
 

--- a/README.md
+++ b/README.md
@@ -5,9 +5,10 @@
 [![Test](https://github.com/ustctug/ustcthesis/actions/workflows/test.yml/badge.svg)](https://github.com/ustctug/ustcthesis/actions/workflows/test.yml)
 
 本项目是中国科学技术大学的学位论文 LaTeX 模板 ustcthesis，按照
-研究生《[学位论文撰写模板](https://gradschool.ustc.edu.cn/column/65)》（2024-12-05）
+研究生院《[学位论文撰写模板](https://gradschool.ustc.edu.cn/column/65)》（2025-03-31）、
+教务处《[\[2025\]32号 中国科学技术大学本科毕业论文（设计）质量标准（试行）](https://www.teach.ustc.edu.cn/?attachment_id=19501)》
 和
-《[中国科学技术大学本科毕业论文（设计）格式](https://www.teach.ustc.edu.cn/?attachment_id=13867)》
+《[中国科学技术大学本科毕业论文（设计）格式式样](https://www.teach.ustc.edu.cn/?attachment_id=13867)》（2026-04-24）
 的要求编写，兼容最新版的 TeX Live、MacTeX 、MiKTeX 发行版，支持跨平台使用。
 
 注意：

--- a/test/testfiles-biblatex/biblatex-bachelor.tlg
+++ b/test/testfiles-biblatex/biblatex-bachelor.tlg
@@ -32,7 +32,7 @@ Completed box being shipped out [1]
 ....\special{color pop}
 ..\glue 15.6491
 ..\glue(\lineskip) 0.0
-..\vbox(700.50723+0.0)x417.11752, glue set 377.1681fil
+..\vbox(700.50723+0.0)x417.11752, glue set 405.26999fil
 ...\write-{}
 ...\glue(\topskip) 1.07475
 ...\hbox(10.92525+2.144)x417.11752, glue set 282.80043fil
@@ -84,7 +84,7 @@ Completed box being shipped out [1]
 ....\glue(\rightskip) 0.0
 ...\glue(\parskip) 0.0
 ...\glue(\parskip) 0.0
-...\glue(\baselineskip) 9.01324
+...\glue(\baselineskip) 7.00575
 ...\hbox(10.92525+2.144)x417.11752, glue set 269.2498fil
 ....\hbox(0.0+0.0)x24.09
 ....\TU/FandolSong(0)/m/n/12.045 引
@@ -139,7 +139,7 @@ Completed box being shipped out [1]
 ....\glue(\rightskip) 0.0
 ...\glue(\parskip) 0.0
 ...\glue(\parskip) 0.0
-...\glue(\baselineskip) 9.01324
+...\glue(\baselineskip) 7.00575
 ...\hbox(10.92525+2.144)x417.11752, glue set 333.81418fil
 ....\hbox(0.0+0.0)x24.09
 ....\TU/FandolSong(0)/m/n/12.045 引
@@ -172,7 +172,7 @@ Completed box being shipped out [1]
 ....\glue(\rightskip) 0.0
 ...\glue(\parskip) 0.0
 ...\glue(\parskip) 0.0
-...\glue(\baselineskip) 9.01324
+...\glue(\baselineskip) 7.00575
 ...\hbox(10.92525+2.144)x417.11752, glue set 324.78043fil
 ....\hbox(0.0+0.0)x24.09
 ....\TU/FandolSong(0)/m/n/12.045 引
@@ -208,7 +208,7 @@ Completed box being shipped out [1]
 ....\glue(\rightskip) 0.0
 ...\glue(\parskip) 0.0
 ...\glue(\parskip) 0.0
-...\glue(\baselineskip) 8.55252
+...\glue(\baselineskip) 6.54503
 ...\hbox(11.38597+2.144)x417.11752, glue set 322.52199fil
 ....\hbox(0.0+0.0)x24.09
 ....\TU/FandolSong(0)/m/n/12.045 引
@@ -245,7 +245,7 @@ Completed box being shipped out [1]
 ....\glue(\rightskip) 0.0
 ...\glue(\parskip) 0.0
 ...\glue(\parskip) 0.0
-...\glue(\baselineskip) 8.55252
+...\glue(\baselineskip) 6.54503
 ...\hbox(11.38597+2.144)x417.11752, glue set 313.48824fil
 ....\hbox(0.0+0.0)x24.09
 ....\TU/FandolSong(0)/m/n/12.045 引
@@ -285,7 +285,7 @@ Completed box being shipped out [1]
 ....\glue(\rightskip) 0.0
 ...\glue(\parskip) 0.0
 ...\glue(\parskip) 0.0
-...\glue(\baselineskip) 9.01324
+...\glue(\baselineskip) 7.00575
 ...\hbox(10.92525+0.16861)x417.11752, glue set 235.81288fil
 ....\hbox(0.0+0.0)x24.09
 ....\TU/texgyretermes(0)/m/n/12.045 Citation
@@ -328,7 +328,7 @@ Completed box being shipped out [1]
 ....\glue(\rightskip) 0.0
 ...\glue(\parskip) 0.0
 ...\glue(\parskip) 0.0
-...\glue(\baselineskip) 10.98863
+...\glue(\baselineskip) 8.98114
 ...\hbox(10.92525+0.16861)x417.11752, glue set 222.26225fil
 ....\hbox(0.0+0.0)x24.09
 ....\TU/texgyretermes(0)/m/n/12.045 Citation
@@ -376,7 +376,7 @@ Completed box being shipped out [1]
 ....\glue(\rightskip) 0.0
 ...\glue(\parskip) 0.0
 ...\glue(\parskip) 0.0
-...\glue(\baselineskip) 10.98863
+...\glue(\baselineskip) 8.98114
 ...\hbox(10.92525+0.16861)x417.11752, glue set 323.61206fil
 ....\hbox(0.0+0.0)x24.09
 ....\TU/texgyretermes(0)/m/n/12.045 Citation
@@ -406,7 +406,7 @@ Completed box being shipped out [1]
 ....\glue(\rightskip) 0.0
 ...\glue(\parskip) 0.0
 ...\glue(\parskip) 0.0
-...\glue(\baselineskip) 10.98863
+...\glue(\baselineskip) 8.98114
 ...\hbox(10.92525+0.16861)x417.11752, glue set 314.57831fil
 ....\hbox(0.0+0.0)x24.09
 ....\TU/texgyretermes(0)/m/n/12.045 Citation
@@ -439,7 +439,7 @@ Completed box being shipped out [1]
 ....\glue(\rightskip) 0.0
 ...\glue(\parskip) 0.0
 ...\glue(\parskip) 0.0
-...\glue(\baselineskip) 10.98863
+...\glue(\baselineskip) 8.98114
 ...\hbox(10.92525+0.16861)x417.11752, glue set 309.81752fil
 ....\hbox(0.0+0.0)x24.09
 ....\TU/texgyretermes(0)/m/n/12.045 Citation
@@ -471,7 +471,7 @@ Completed box being shipped out [1]
 ....\glue(\rightskip) 0.0
 ...\glue(\parskip) 0.0
 ...\glue(\parskip) 0.0
-...\glue(\baselineskip) 10.98863
+...\glue(\baselineskip) 8.98114
 ...\hbox(10.92525+0.16861)x417.11752, glue set 300.78377fil
 ....\hbox(0.0+0.0)x24.09
 ....\TU/texgyretermes(0)/m/n/12.045 Citation
@@ -506,7 +506,7 @@ Completed box being shipped out [1]
 ....\glue(\rightskip) 0.0
 ...\glue(\parskip) 0.0
 ...\glue(\parskip) 0.0
-...\glue(\baselineskip) 10.98863
+...\glue(\baselineskip) 8.98114
 ...\hbox(10.92525+2.144)x417.11752, glue set 333.81418fil
 ....\hbox(0.0+0.0)x24.09
 ....\TU/FandolSong(0)/m/n/12.045 引
@@ -539,7 +539,7 @@ Completed box being shipped out [1]
 ....\glue(\rightskip) 0.0
 ...\glue(\parskip) 0.0
 ...\glue(\parskip) 0.0
-...\glue(\baselineskip) 9.01324
+...\glue(\baselineskip) 7.00575
 ...\hbox(10.92525+2.144)x417.11752, glue set 326.28906fil
 ....\hbox(0.0+0.0)x24.09
 ....\TU/FandolSong(0)/m/n/12.045 引
@@ -578,7 +578,7 @@ Completed box being shipped out [1]
 ....\glue(\rightskip) 0.0
 ...\glue(\parskip) 0.0
 ...\glue(\parskip) 0.0
-...\glue(\baselineskip) 9.01324
+...\glue(\baselineskip) 7.00575
 ...\hbox(10.92525+2.144)x417.11752, glue set 326.28906fil
 ....\hbox(0.0+0.0)x24.09
 ....\TU/FandolSong(0)/m/n/12.045 引
@@ -642,7 +642,7 @@ Completed box being shipped out [2]
 ....\special{color pop}
 ..\glue 15.6491
 ..\glue(\lineskip) 0.0
-..\vbox(700.50723+0.0)x417.11752, glue set 472.03236fil
+..\vbox(700.50723+0.0)x417.11752, glue set 486.0833fil
 ...\write-{}
 ...\write-{}
 ...\write1{\@writefile{toc}{\protect \contentsline {chapter}{参考文献}{\thepage }{}\protected@file@percent }}
@@ -672,7 +672,7 @@ Completed box being shipped out [2]
 ...\glue 19.07124
 ...\glue(\parskip) 0.0
 ...\glue(\parskip) 0.0
-...\glue(\baselineskip) 9.27867
+...\glue(\baselineskip) 7.27118
 ...\hbox(9.40715+2.18013)x387.00504, glue set 0.40877, shifted 30.11249
 ....\hbox(8.14243+1.879)x0.0
 .....\glue 0.0
@@ -787,7 +787,7 @@ Completed box being shipped out [2]
 ....\discretionary
 ....\glue(\rightskip) 0.0
 ...\penalty 400
-...\glue(\baselineskip) 11.75993
+...\glue(\baselineskip) 9.75244
 ...\hbox(8.14243+0.16861)x387.00504, glue set 371.94899fil, shifted 30.11249
 ....\TU/texgyretermes(0)/m/n/12.045 40
 ....\kern -0.0002
@@ -801,7 +801,7 @@ Completed box being shipped out [2]
 ...\glue 0.0 plus 0.2
 ...\glue(\parskip) 0.0
 ...\glue(\parskip) 0.0
-...\glue(\baselineskip) 12.45856
+...\glue(\baselineskip) 10.45107
 ...\hbox(9.45532+2.16809)x387.00504, glue set 0.3087, shifted 30.11249
 ....\hbox(8.14243+1.879)x0.0
 .....\glue 0.0
@@ -906,7 +906,7 @@ Completed box being shipped out [2]
 ....\TU/FandolSong(0)/m/n/12.045 版
 ....\glue(\rightskip) 0.0
 ...\penalty 300
-...\glue(\baselineskip) 10.74815
+...\glue(\baselineskip) 8.74066
 ...\hbox(9.16624+2.03558)x387.00504, glue set 308.37962fil, shifted 30.11249
 ....\TU/FandolSong(0)/m/n/12.045 社
 ....\kern -0.00017
@@ -931,7 +931,7 @@ Completed box being shipped out [2]
 ...\glue 0.0 plus 0.2
 ...\glue(\parskip) 0.0
 ...\glue(\parskip) 0.0
-...\glue(\baselineskip) 11.82018
+...\glue(\baselineskip) 9.81268
 ...\hbox(8.22673+2.6258)x387.00504, glue set 23.98146fil, shifted 30.11249
 ....\hbox(8.14243+1.879)x0.0
 .....\glue 0.0
@@ -1002,7 +1002,7 @@ Completed box being shipped out [2]
 ...\glue 0.0 plus 0.2
 ...\glue(\parskip) 0.0
 ...\glue(\parskip) 0.0
-...\glue(\baselineskip) 11.22997
+...\glue(\baselineskip) 9.22247
 ...\hbox(8.22673+2.61375)x387.00504, glue set 0.31708, shifted 30.11249
 ....\hbox(8.14243+1.879)x0.0
 .....\glue 0.0
@@ -1053,7 +1053,7 @@ Completed box being shipped out [2]
 ....\TU/texgyretermes(0)/m/n/12.045 potential
 ....\glue(\rightskip) 0.0
 ...\penalty 300
-...\glue(\baselineskip) 11.22995
+...\glue(\baselineskip) 9.22246
 ...\hbox(8.23878+2.6258)x387.00504, glue set 36.51222fil, shifted 30.11249
 ....\TU/texgyretermes(0)/m/n/12.045 of
 ....\glue 3.01125 plus 1.50562 minus 1.00374

--- a/test/testfiles-biblatex/biblatex-bachelor.tlg
+++ b/test/testfiles-biblatex/biblatex-bachelor.tlg
@@ -645,7 +645,7 @@ Completed box being shipped out [2]
 ..\vbox(700.50723+0.0)x417.11752, glue set 486.0833fil
 ...\write-{}
 ...\write-{}
-...\write1{\@writefile{toc}{\protect \contentsline {chapter}{参考文献}{\thepage }{}\protected@file@percent }}
+...\write1{\@writefile{toc}{\protect \contentsline {chapter}{参\protect \enspace  考\protect \enspace  文\protect \enspace  献}{\thepage }{}\protected@file@percent }}
 ...\glue(\topskip) 12.0
 ...\rule(0.0+0.0)x*
 ...\penalty 10000
@@ -657,11 +657,17 @@ Completed box being shipped out [2]
 ...\hbox(14.18298+3.39667)x417.11752, glue set 158.87318fil
 ....\glue(\leftskip) 0.0 plus 1.0fil
 ....\TU/FandolHei(0)/m/n/18.06749 参
-....\glue 9.03374 plus 1.40234 minus 0.4979
+....\kern -0.00017
+....\kern 0.00017
+....\kern 9.03374
 ....\TU/FandolHei(0)/m/n/18.06749 考
-....\glue 9.03374 plus 1.40234 minus 0.4979
+....\kern -0.00017
+....\kern 0.00017
+....\kern 9.03374
 ....\TU/FandolHei(0)/m/n/18.06749 文
-....\glue 9.03374 plus 1.40234 minus 0.4979
+....\kern -0.00017
+....\kern 0.00017
+....\kern 9.03374
 ....\TU/FandolHei(0)/m/n/18.06749 献
 ....\kern -0.00017
 ....\kern 0.00017

--- a/test/testfiles-bibtex/bibtex-bachelor.tlg
+++ b/test/testfiles-bibtex/bibtex-bachelor.tlg
@@ -32,7 +32,7 @@ Completed box being shipped out [1]
 ....\special{color pop}
 ..\glue 15.6491
 ..\glue(\lineskip) 0.0
-..\vbox(700.50723+0.0)x417.11752, glue set 377.1681fil
+..\vbox(700.50723+0.0)x417.11752, glue set 405.26999fil
 ...\write-{}
 ...\glue(\topskip) 1.07475
 ...\hbox(10.92525+2.144)x417.11752, glue set 279.62294fil
@@ -83,7 +83,7 @@ Completed box being shipped out [1]
 ....\glue(\rightskip) 0.0
 ...\glue(\parskip) 0.0
 ...\glue(\parskip) 0.0
-...\glue(\baselineskip) 9.01324
+...\glue(\baselineskip) 7.00575
 ...\hbox(10.92525+2.144)x417.11752, glue set 270.08919fil
 ....\hbox(0.0+0.0)x24.09
 ....\TU/FandolSong(0)/m/n/12.045 引
@@ -138,7 +138,7 @@ Completed box being shipped out [1]
 ....\glue(\rightskip) 0.0
 ...\glue(\parskip) 0.0
 ...\glue(\parskip) 0.0
-...\glue(\baselineskip) 9.01324
+...\glue(\baselineskip) 7.00575
 ...\hbox(10.92525+2.144)x417.11752, glue set 331.81418fil
 ....\hbox(0.0+0.0)x24.09
 ....\TU/FandolSong(0)/m/n/12.045 引
@@ -169,7 +169,7 @@ Completed box being shipped out [1]
 ....\glue(\rightskip) 0.0
 ...\glue(\parskip) 0.0
 ...\glue(\parskip) 0.0
-...\glue(\baselineskip) 9.01324
+...\glue(\baselineskip) 7.00575
 ...\hbox(10.92525+2.144)x417.11752, glue set 322.78043fil
 ....\hbox(0.0+0.0)x24.09
 ....\TU/FandolSong(0)/m/n/12.045 引
@@ -200,7 +200,7 @@ Completed box being shipped out [1]
 ....\glue(\rightskip) 0.0
 ...\glue(\parskip) 0.0
 ...\glue(\parskip) 0.0
-...\glue(\baselineskip) 9.01324
+...\glue(\baselineskip) 7.00575
 ...\hbox(10.92525+2.144)x417.11752, glue set 319.76918fil
 ....\hbox(0.0+0.0)x24.09
 ....\TU/FandolSong(0)/m/n/12.045 引
@@ -233,7 +233,7 @@ Completed box being shipped out [1]
 ....\glue(\rightskip) 0.0
 ...\glue(\parskip) 0.0
 ...\glue(\parskip) 0.0
-...\glue(\baselineskip) 9.01324
+...\glue(\baselineskip) 7.00575
 ...\hbox(10.92525+2.144)x417.11752, glue set 310.73543fil
 ....\hbox(0.0+0.0)x24.09
 ....\TU/FandolSong(0)/m/n/12.045 引
@@ -266,7 +266,7 @@ Completed box being shipped out [1]
 ....\glue(\rightskip) 0.0
 ...\glue(\parskip) 0.0
 ...\glue(\parskip) 0.0
-...\glue(\baselineskip) 9.01324
+...\glue(\baselineskip) 7.00575
 ...\hbox(10.92525+0.16861)x417.11752, glue set 232.63539fil
 ....\hbox(0.0+0.0)x24.09
 ....\TU/texgyretermes(0)/m/n/12.045 Citation
@@ -308,7 +308,7 @@ Completed box being shipped out [1]
 ....\glue(\rightskip) 0.0
 ...\glue(\parskip) 0.0
 ...\glue(\parskip) 0.0
-...\glue(\baselineskip) 10.98863
+...\glue(\baselineskip) 8.98114
 ...\hbox(10.92525+0.16861)x417.11752, glue set 223.10164fil
 ....\hbox(0.0+0.0)x24.09
 ....\TU/texgyretermes(0)/m/n/12.045 Citation
@@ -356,7 +356,7 @@ Completed box being shipped out [1]
 ....\glue(\rightskip) 0.0
 ...\glue(\parskip) 0.0
 ...\glue(\parskip) 0.0
-...\glue(\baselineskip) 10.98863
+...\glue(\baselineskip) 8.98114
 ...\hbox(10.92525+0.16861)x417.11752, glue set 321.61206fil
 ....\hbox(0.0+0.0)x24.09
 ....\TU/texgyretermes(0)/m/n/12.045 Citation
@@ -384,7 +384,7 @@ Completed box being shipped out [1]
 ....\glue(\rightskip) 0.0
 ...\glue(\parskip) 0.0
 ...\glue(\parskip) 0.0
-...\glue(\baselineskip) 10.98863
+...\glue(\baselineskip) 8.98114
 ...\hbox(10.92525+0.16861)x417.11752, glue set 312.57831fil
 ....\hbox(0.0+0.0)x24.09
 ....\TU/texgyretermes(0)/m/n/12.045 Citation
@@ -412,7 +412,7 @@ Completed box being shipped out [1]
 ....\glue(\rightskip) 0.0
 ...\glue(\parskip) 0.0
 ...\glue(\parskip) 0.0
-...\glue(\baselineskip) 10.98863
+...\glue(\baselineskip) 8.98114
 ...\hbox(10.92525+0.16861)x417.11752, glue set 303.21935fil
 ....\hbox(0.0+0.0)x24.09
 ....\TU/texgyretermes(0)/m/n/12.045 Citation
@@ -442,7 +442,7 @@ Completed box being shipped out [1]
 ....\glue(\rightskip) 0.0
 ...\glue(\parskip) 0.0
 ...\glue(\parskip) 0.0
-...\glue(\baselineskip) 10.98863
+...\glue(\baselineskip) 8.98114
 ...\hbox(10.92525+0.16861)x417.11752, glue set 294.1856fil
 ....\hbox(0.0+0.0)x24.09
 ....\TU/texgyretermes(0)/m/n/12.045 Citation
@@ -472,7 +472,7 @@ Completed box being shipped out [1]
 ....\glue(\rightskip) 0.0
 ...\glue(\parskip) 0.0
 ...\glue(\parskip) 0.0
-...\glue(\baselineskip) 10.98863
+...\glue(\baselineskip) 8.98114
 ...\hbox(10.92525+2.144)x417.11752, glue set 331.81418fil
 ....\hbox(0.0+0.0)x24.09
 ....\TU/FandolSong(0)/m/n/12.045 引
@@ -503,7 +503,7 @@ Completed box being shipped out [1]
 ....\glue(\rightskip) 0.0
 ...\glue(\parskip) 0.0
 ...\glue(\parskip) 0.0
-...\glue(\baselineskip) 9.01324
+...\glue(\baselineskip) 7.00575
 ...\hbox(10.92525+2.144)x417.11752, glue set 324.28906fil
 ....\hbox(0.0+0.0)x24.09
 ....\TU/FandolSong(0)/m/n/12.045 引
@@ -542,7 +542,7 @@ Completed box being shipped out [1]
 ....\glue(\rightskip) 0.0
 ...\glue(\parskip) 0.0
 ...\glue(\parskip) 0.0
-...\glue(\baselineskip) 9.01324
+...\glue(\baselineskip) 7.00575
 ...\hbox(10.92525+2.144)x417.11752, glue set 324.28906fil
 ....\hbox(0.0+0.0)x24.09
 ....\TU/FandolSong(0)/m/n/12.045 引
@@ -608,7 +608,7 @@ Completed box being shipped out [2]
 ....\special{color pop}
 ..\glue 15.6491
 ..\glue(\lineskip) 0.0
-..\vbox(700.50723+0.0)x417.11752, glue set 472.03236fil
+..\vbox(700.50723+0.0)x417.11752, glue set 486.0833fil
 ...\write-{}
 ...\write-{}
 ...\write1{\@writefile{toc}{\protect \contentsline {chapter}{参考文献}{\thepage }{}\protected@file@percent }}
@@ -638,7 +638,7 @@ Completed box being shipped out [2]
 ...\glue 19.07124
 ...\glue(\parskip) 0.0
 ...\glue(\parskip) 0.0
-...\glue(\baselineskip) 9.27867
+...\glue(\baselineskip) 7.27118
 ...\hbox(9.40715+2.18013)x387.00504, glue set 0.83244, shifted 30.11249
 ....\hbox(8.14243+1.879)x0.0
 .....\glue 0.0
@@ -717,7 +717,7 @@ Completed box being shipped out [2]
 ....\TU/texgyretermes(0)/m/n/12.045 (4):
 ....\glue(\rightskip) 0.0
 ...\penalty 14000
-...\glue(\baselineskip) 11.6154
+...\glue(\baselineskip) 9.60791
 ...\hbox(8.28696+0.16861)x387.00504, glue set 355.8928fil, shifted 30.11249
 ....\TU/texgyretermes(0)/m/n/12.045 35-40.
 ....\penalty 10000
@@ -727,7 +727,7 @@ Completed box being shipped out [2]
 ...\glue 0.0 plus 0.2
 ...\glue(\parskip) 0.0
 ...\glue(\parskip) 0.0
-...\glue(\baselineskip) 12.45856
+...\glue(\baselineskip) 10.45107
 ...\hbox(9.45532+2.16809)x387.00504, glue set 0.09201, shifted 30.11249
 ....\hbox(8.14243+1.879)x0.0
 .....\glue 0.0
@@ -810,7 +810,7 @@ Completed box being shipped out [2]
 ....\TU/FandolSong(0)/m/n/12.045 版
 ....\glue(\rightskip) 0.0
 ...\penalty 4150
-...\glue(\baselineskip) 10.74815
+...\glue(\baselineskip) 8.74066
 ...\hbox(9.16624+2.03558)x387.00504, glue set 306.37183fil, shifted 30.11249
 ....\TU/FandolSong(0)/m/n/12.045 社
 ....\TU/texgyretermes(0)/m/n/12.045 ,
@@ -825,7 +825,7 @@ Completed box being shipped out [2]
 ...\glue 0.0 plus 0.2
 ...\glue(\parskip) 0.0
 ...\glue(\parskip) 0.0
-...\glue(\baselineskip) 11.82018
+...\glue(\baselineskip) 9.81268
 ...\hbox(8.22673+2.6258)x387.00504, glue set 21.33096fil, shifted 30.11249
 ....\hbox(8.14243+1.879)x0.0
 .....\glue 0.0
@@ -875,7 +875,7 @@ Completed box being shipped out [2]
 ...\glue 0.0 plus 0.2
 ...\glue(\parskip) 0.0
 ...\glue(\parskip) 0.0
-...\glue(\baselineskip) 11.22997
+...\glue(\baselineskip) 9.22247
 ...\hbox(8.22673+2.61375)x387.00504, glue set 0.16972, shifted 30.11249
 ....\hbox(8.14243+1.879)x0.0
 .....\glue 0.0
@@ -917,7 +917,7 @@ Completed box being shipped out [2]
 ....\TU/texgyretermes(0)/m/n/12.045 potential
 ....\glue(\rightskip) 0.0
 ...\penalty 4150
-...\glue(\baselineskip) 11.22995
+...\glue(\baselineskip) 9.22246
 ...\hbox(8.23878+2.6258)x387.00504, glue set 33.17924fil, shifted 30.11249
 ....\TU/texgyretermes(0)/m/n/12.045 of
 ....\glue 3.01125 plus 1.50562 minus 1.00374

--- a/test/testfiles-bibtex/bibtex-bachelor.tlg
+++ b/test/testfiles-bibtex/bibtex-bachelor.tlg
@@ -611,7 +611,7 @@ Completed box being shipped out [2]
 ..\vbox(700.50723+0.0)x417.11752, glue set 486.0833fil
 ...\write-{}
 ...\write-{}
-...\write1{\@writefile{toc}{\protect \contentsline {chapter}{参考文献}{\thepage }{}\protected@file@percent }}
+...\write1{\@writefile{toc}{\protect \contentsline {chapter}{参\protect \enspace  考\protect \enspace  文\protect \enspace  献}{\thepage }{}\protected@file@percent }}
 ...\glue(\topskip) 12.0
 ...\rule(0.0+0.0)x*
 ...\penalty 10000
@@ -623,11 +623,17 @@ Completed box being shipped out [2]
 ...\hbox(14.18298+3.39667)x417.11752, glue set 158.87318fil
 ....\glue(\leftskip) 0.0 plus 1.0fil
 ....\TU/FandolHei(0)/m/n/18.06749 参
-....\glue 9.03374 plus 1.40234 minus 0.4979
+....\kern -0.00017
+....\kern 0.00017
+....\kern 9.03374
 ....\TU/FandolHei(0)/m/n/18.06749 考
-....\glue 9.03374 plus 1.40234 minus 0.4979
+....\kern -0.00017
+....\kern 0.00017
+....\kern 9.03374
 ....\TU/FandolHei(0)/m/n/18.06749 文
-....\glue 9.03374 plus 1.40234 minus 0.4979
+....\kern -0.00017
+....\kern 0.00017
+....\kern 9.03374
 ....\TU/FandolHei(0)/m/n/18.06749 献
 ....\kern -0.00017
 ....\kern 0.00017

--- a/test/testfiles-crossref/main-bachelor-arabic.tlg
+++ b/test/testfiles-crossref/main-bachelor-arabic.tlg
@@ -83,7 +83,7 @@ Completed box being shipped out [1]
 ....\special{color pop}
 ..\glue 15.6491
 ..\glue(\lineskip) 0.0
-..\vbox(700.50723+0.0)x417.11752, glue set 494.52197fil
+..\vbox(700.50723+0.0)x417.11752, glue set 506.56564fil
 ...\write-{}
 ...\write-{}
 ...\write-{}
@@ -111,7 +111,7 @@ Completed box being shipped out [1]
 ...\glue 19.07124
 ...\glue(\parskip) 0.0
 ...\glue(\parskip) 0.0
-...\glue(\baselineskip) 9.54367
+...\glue(\baselineskip) 7.53618
 ...\hbox(9.3951+2.32468)x417.11752, glue set 0.41225
 ....\hbox(0.0+0.0)x24.09
 ....\TU/FandolSong(0)/m/n/12.045 研
@@ -181,7 +181,7 @@ Completed box being shipped out [1]
 ....\TU/FandolSong(0)/m/n/12.045 研
 ....\glue(\rightskip) 0.0
 ...\penalty 10150
-...\glue(\baselineskip) 10.36272
+...\glue(\baselineskip) 8.35522
 ...\hbox(9.3951+2.32468)x417.11752, glue set 99.65955fil
 ....\TU/FandolSong(0)/m/n/12.045 究
 ....\glue 0.0 plus 0.61353
@@ -248,7 +248,7 @@ Completed box being shipped out [1]
 ....\glue(\rightskip) 0.0
 ...\glue(\parskip) 0.0
 ...\glue(\parskip) 0.0
-...\glue(\baselineskip) 15.51797
+...\glue(\baselineskip) 13.51048
 ...\hbox(4.23984+0.0)x417.11752, glue set 370.98518fil
 ....\hbox(0.0+0.0)x24.09
 ....\penalty 0
@@ -264,11 +264,11 @@ Completed box being shipped out [1]
 ....\penalty 10000
 ....\glue(\parfillskip) 0.0 plus 1.0fil
 ....\glue(\rightskip) 0.0
-...\glue(\baselineskip) 22.08249
+...\glue(\baselineskip) 20.075
 ...\hbox(0.0+0.0)x0.0
 ...\glue(\parskip) 0.0
 ...\glue(\parskip) 0.0
-...\glue(\baselineskip) 12.6874
+...\glue(\baselineskip) 10.6799
 ...\hbox(9.3951+2.21626)x417.11752, glue set - 0.03065
 ....\TU/FandolSong(0)/b/n/12.045 关
 ....\glue 0.0 plus 0.61353
@@ -357,7 +357,7 @@ Completed box being shipped out [1]
 ....\TU/FandolSong(0)/m/n/12.045 键
 ....\glue(\rightskip) 0.0
 ...\penalty 300
-...\glue(\baselineskip) 10.59158
+...\glue(\baselineskip) 8.58409
 ...\hbox(9.27464+2.21626)x368.93753, glue set 290.64503fil, shifted 48.18
 ....\TU/FandolSong(0)/m/n/12.045 词
 ....\glue 3.01125 plus 1.50562 minus 1.00374
@@ -382,14 +382,14 @@ Completed box being shipped out [1]
 ...\glue 0.0 plus 1.0fil
 ...\glue 0.0
 ...\glue 0.0 plus 0.0001fil
-..\glue(\baselineskip) 15.85268
-..\hbox(6.6248+0.0)x417.11752
+..\glue(\baselineskip) 16.45493
+..\hbox(6.02255+0.0)x417.11752
 ...\special{color push  Black}
-...\hbox(6.6248+0.0)x417.11752
-....\hbox(6.6248+0.0)x417.11752
-.....\vbox(6.6248+0.0)x417.11752
+...\hbox(6.02255+0.0)x417.11752
+....\hbox(6.02255+0.0)x417.11752
+.....\vbox(6.02255+0.0)x417.11752
 ......\rule(0.0+0.0)x417.11752
-......\glue 6.6248
+......\glue 6.02255
 ......\hbox(0.0+0.0)x417.11752
 .......\hbox(0.0+0.0)x0.0, glue set - 417.11752fil
 ........\vbox(0.0+0.0)x417.11752
@@ -494,7 +494,7 @@ Completed box being shipped out [2]
 ....\special{color pop}
 ..\glue 15.6491
 ..\glue(\lineskip) 0.0
-..\vbox(700.50723+0.0)x417.11752, glue set 472.03236fil
+..\vbox(700.50723+0.0)x417.11752, glue set 486.0833fil
 ...\write-{}
 ...\write-{}
 ...\glue(\topskip) 12.0
@@ -517,7 +517,7 @@ Completed box being shipped out [2]
 ...\glue 19.07124
 ...\glue(\parskip) 0.0
 ...\glue(\parskip) 0.0
-...\glue(\baselineskip) 13.60283
+...\glue(\baselineskip) 11.59534
 ...\hbox(8.22673+2.6258)x417.11752, glue set 0.27924
 ....\hbox(0.0+0.0)x24.09
 ....\TU/texgyretermes(0)/m/n/12.045 Graduate
@@ -545,7 +545,7 @@ Completed box being shipped out [2]
 ....\TU/texgyretermes(0)/m/n/12.045 re-
 ....\glue(\rightskip) 0.0
 ...\penalty 250
-...\glue(\baselineskip) 11.22997
+...\glue(\baselineskip) 9.22247
 ...\hbox(8.22673+2.6258)x417.11752, glue set 0.71335
 ....\TU/texgyretermes(0)/m/n/12.045 flection,
 ....\glue 3.01125 plus 1.88202 minus 0.80298
@@ -578,7 +578,7 @@ Completed box being shipped out [2]
 ....\TU/texgyretermes(0)/m/n/12.045 of
 ....\glue(\rightskip) 0.0
 ...\penalty 150
-...\glue(\baselineskip) 11.22997
+...\glue(\baselineskip) 9.22247
 ...\hbox(8.22673+2.6258)x417.11752, glue set 193.466fil
 ....\TU/texgyretermes(0)/m/n/12.045 application
 ....\glue 3.01125 plus 1.50562 minus 1.00374
@@ -596,18 +596,18 @@ Completed box being shipped out [2]
 ....\glue(\rightskip) 0.0
 ...\glue(\parskip) 0.0
 ...\glue(\parskip) 0.0
-...\glue(\baselineskip) 18.2522
+...\glue(\baselineskip) 16.2447
 ...\hbox(1.2045+0.13248)x417.11752, glue set 380.98253fil
 ....\hbox(0.0+0.0)x24.09
 ....\TU/texgyretermes(0)/m/n/12.045 …
 ....\penalty 10000
 ....\glue(\parfillskip) 0.0 plus 1.0fil
 ....\glue(\rightskip) 0.0
-...\glue(\baselineskip) 21.95001
+...\glue(\baselineskip) 19.94252
 ...\hbox(0.0+0.0)x0.0
 ...\glue(\parskip) 0.0
 ...\glue(\parskip) 0.0
-...\glue(\baselineskip) 13.79553
+...\glue(\baselineskip) 11.78804
 ...\hbox(8.28696+2.6258)x417.11752, glue set - 0.68094
 ....\TU/texgyretermes(0)/b/n/12.045 Key
 ....\glue 3.01125 plus 1.50562 minus 1.00374
@@ -642,7 +642,7 @@ Completed box being shipped out [2]
 ....\TU/texgyretermes(0)/m/n/12.045 Keyword
 ....\glue(\rightskip) 0.0
 ...\penalty 300
-...\glue(\baselineskip) 11.21791
+...\glue(\baselineskip) 9.21042
 ...\hbox(8.23878+2.6258)x338.82504, glue set 208.40184fil, shifted 78.29248
 ....\TU/texgyretermes(0)/m/n/12.045 6;
 ....\glue 3.01125 plus 2.25842 minus 0.66916
@@ -663,15 +663,15 @@ Completed box being shipped out [2]
 ...\glue 0.0 plus 1.0fil
 ...\glue 0.0
 ...\glue 0.0 plus 0.0001fil
-..\glue(\baselineskip) 15.85268
-..\hbox(6.6248+0.0)x417.11752
+..\glue(\baselineskip) 16.45493
+..\hbox(6.02255+0.0)x417.11752
 ...\special{color push  Black}
-...\hbox(6.6248+0.0)x417.11752
+...\hbox(6.02255+0.0)x417.11752
 ....\glue 0.0 plus 1.0fil minus 1.0fil
-....\hbox(6.6248+0.0)x417.11752
-.....\vbox(6.6248+0.0)x417.11752
+....\hbox(6.02255+0.0)x417.11752
+.....\vbox(6.02255+0.0)x417.11752
 ......\rule(0.0+0.0)x417.11752
-......\glue 6.6248
+......\glue 6.02255
 ......\hbox(0.0+0.0)x417.11752
 .......\hbox(0.0+0.0)x0.0, glue set - 417.11752fil
 ........\vbox(0.0+0.0)x417.11752
@@ -777,7 +777,7 @@ Completed box being shipped out [1]
 ....\special{color pop}
 ..\glue 15.6491
 ..\glue(\lineskip) 0.0
-..\vbox(700.50723+0.0)x417.11752, glue set 321.50198fil
+..\vbox(700.50723+0.0)x417.11752, glue set 346.19151fil
 ...\write-{}
 ...\write-{}
 ...\write-{}
@@ -806,11 +806,11 @@ Completed box being shipped out [1]
 ...\penalty 10000
 ...\glue(\parskip) 0.0
 ...\glue(\parskip) 0.0
-...\glue(\baselineskip) 3.51723
-...\hbox(15.45767+6.6248)x417.11752, glue set 335.8138fill
+...\glue(\baselineskip) 2.91498
+...\hbox(14.05243+6.02255)x417.11752, glue set 335.8138fill
 ....\glue(\leftskip) 48.18
 ....\hbox(0.0+0.0)x0.0
-....\rule(15.45767+6.6248)x0.0
+....\rule(14.05243+6.02255)x0.0
 ....\hbox(9.35896+2.21626)x0.0, glue set - 48.18fil
 .....\glue 0.0 plus 1.0fil minus 1.0fil
 .....\hbox(9.35896+2.21626)x48.18
@@ -829,7 +829,7 @@ Completed box being shipped out [1]
 ....\TU/FandolSong(0)/m/n/12.045 言
 ....\kern -0.00017
 ....\kern 0.00017
-....\rule(15.45767+6.6248)x0.0
+....\rule(14.05243+6.02255)x0.0
 ....\kern 0.0
 ....\glue 2.00749
 ....\glue -4.015
@@ -858,10 +858,10 @@ Completed box being shipped out [1]
 ...\glue(\parskip) 0.0
 ...\glue(\parskip) 0.0
 ...\glue(\baselineskip) 0.00002
-...\hbox(15.45767+6.6248)x417.11752, glue set 224.39757fill
+...\hbox(14.05243+6.02255)x417.11752, glue set 224.39757fill
 ....\glue(\leftskip) 39.14624
 ....\hbox(0.0+0.0)x0.0
-....\rule(15.45767+6.6248)x0.0
+....\rule(14.05243+6.02255)x0.0
 ....\hbox(8.14243+0.13248)x0.0, glue set - 27.10124fil
 .....\glue 0.0 plus 1.0fil minus 1.0fil
 .....\hbox(8.14243+0.13248)x27.10124
@@ -896,7 +896,7 @@ Completed box being shipped out [1]
 ....\TU/FandolSong(0)/m/n/12.045 析
 ....\kern -0.00017
 ....\kern 0.00017
-....\rule(15.45767+6.6248)x0.0
+....\rule(14.05243+6.02255)x0.0
 ....\kern 0.0
 ....\glue 2.00749
 ....\glue -4.015
@@ -925,10 +925,10 @@ Completed box being shipped out [1]
 ...\glue(\parskip) 0.0
 ...\glue(\parskip) 0.0
 ...\glue(\baselineskip) 0.00002
-...\hbox(15.45767+6.6248)x417.11752, glue set 275.5888fill
+...\hbox(14.05243+6.02255)x417.11752, glue set 275.5888fill
 ....\glue(\leftskip) 60.22499
 ....\hbox(0.0+0.0)x0.0
-....\rule(15.45767+6.6248)x0.0
+....\rule(14.05243+6.02255)x0.0
 ....\hbox(8.14243+0.13248)x0.0, glue set - 36.135fil
 .....\glue 0.0 plus 1.0fil minus 1.0fil
 .....\hbox(8.14243+0.13248)x36.135
@@ -951,7 +951,7 @@ Completed box being shipped out [1]
 ....\TU/FandolSong(0)/m/n/12.045 题
 ....\kern -0.00017
 ....\kern 0.00017
-....\rule(15.45767+6.6248)x0.0
+....\rule(14.05243+6.02255)x0.0
 ....\kern 0.0
 ....\glue 2.00749
 ....\glue -4.015
@@ -984,10 +984,10 @@ Completed box being shipped out [1]
 ...\glue(\parskip) 0.0
 ...\glue(\parskip) 0.0
 ...\glue(\baselineskip) 0.00002
-...\hbox(15.45767+6.6248)x417.11752, glue set 311.7238fill
+...\hbox(14.05243+6.02255)x417.11752, glue set 311.7238fill
 ....\glue(\leftskip) 48.18
 ....\hbox(0.0+0.0)x0.0
-....\rule(15.45767+6.6248)x0.0
+....\rule(14.05243+6.02255)x0.0
 ....\hbox(9.35896+2.21626)x0.0, glue set - 48.18fil
 .....\glue 0.0 plus 1.0fil minus 1.0fil
 .....\hbox(9.35896+2.21626)x48.18
@@ -1010,7 +1010,7 @@ Completed box being shipped out [1]
 ....\TU/FandolSong(0)/m/n/12.045 素
 ....\kern -0.00017
 ....\kern 0.00017
-....\rule(15.45767+6.6248)x0.0
+....\rule(14.05243+6.02255)x0.0
 ....\kern 0.0
 ....\glue 2.00749
 ....\glue -4.015
@@ -1039,10 +1039,10 @@ Completed box being shipped out [1]
 ...\glue(\parskip) 0.0
 ...\glue(\parskip) 0.0
 ...\glue(\baselineskip) 0.00002
-...\hbox(15.45767+6.6248)x417.11752, glue set 260.53256fill
+...\hbox(14.05243+6.02255)x417.11752, glue set 260.53256fill
 ....\glue(\leftskip) 39.14624
 ....\hbox(0.0+0.0)x0.0
-....\rule(15.45767+6.6248)x0.0
+....\rule(14.05243+6.02255)x0.0
 ....\hbox(8.14243+0.13248)x0.0, glue set - 27.10124fil
 .....\glue 0.0 plus 1.0fil minus 1.0fil
 .....\hbox(8.14243+0.13248)x27.10124
@@ -1073,7 +1073,7 @@ Completed box being shipped out [1]
 ....\TU/FandolSong(0)/m/n/12.045 式
 ....\kern -0.00017
 ....\kern 0.00017
-....\rule(15.45767+6.6248)x0.0
+....\rule(14.05243+6.02255)x0.0
 ....\kern 0.0
 ....\glue 2.00749
 ....\glue -4.015
@@ -1102,10 +1102,10 @@ Completed box being shipped out [1]
 ...\glue(\parskip) 0.0
 ...\glue(\parskip) 0.0
 ...\glue(\baselineskip) 0.00002
-...\hbox(15.45767+6.6248)x417.11752, glue set 323.7688fill
+...\hbox(14.05243+6.02255)x417.11752, glue set 323.7688fill
 ....\glue(\leftskip) 60.22499
 ....\hbox(0.0+0.0)x0.0
-....\rule(15.45767+6.6248)x0.0
+....\rule(14.05243+6.02255)x0.0
 ....\hbox(8.14243+0.13248)x0.0, glue set - 36.135fil
 .....\glue 0.0 plus 1.0fil minus 1.0fil
 .....\hbox(8.14243+0.13248)x36.135
@@ -1120,7 +1120,7 @@ Completed box being shipped out [1]
 ....\TU/FandolSong(0)/m/n/12.045 图
 ....\kern -0.00017
 ....\kern 0.00017
-....\rule(15.45767+6.6248)x0.0
+....\rule(14.05243+6.02255)x0.0
 ....\kern 0.0
 ....\glue 2.00749
 ....\glue -4.015
@@ -1149,10 +1149,10 @@ Completed box being shipped out [1]
 ...\glue(\parskip) 0.0
 ...\glue(\parskip) 0.0
 ...\glue(\baselineskip) 0.00002
-...\hbox(15.45767+6.6248)x417.11752, glue set 323.7688fill
+...\hbox(14.05243+6.02255)x417.11752, glue set 323.7688fill
 ....\glue(\leftskip) 60.22499
 ....\hbox(0.0+0.0)x0.0
-....\rule(15.45767+6.6248)x0.0
+....\rule(14.05243+6.02255)x0.0
 ....\hbox(8.14243+0.13248)x0.0, glue set - 36.135fil
 .....\glue 0.0 plus 1.0fil minus 1.0fil
 .....\hbox(8.14243+0.13248)x36.135
@@ -1167,7 +1167,7 @@ Completed box being shipped out [1]
 ....\TU/FandolSong(0)/m/n/12.045 格
 ....\kern -0.00017
 ....\kern 0.00017
-....\rule(15.45767+6.6248)x0.0
+....\rule(14.05243+6.02255)x0.0
 ....\kern 0.0
 ....\glue 2.00749
 ....\glue -4.015
@@ -1196,10 +1196,10 @@ Completed box being shipped out [1]
 ...\glue(\parskip) 0.0
 ...\glue(\parskip) 0.0
 ...\glue(\baselineskip) 0.00002
-...\hbox(15.45767+6.6248)x417.11752, glue set 311.7238fill
+...\hbox(14.05243+6.02255)x417.11752, glue set 311.7238fill
 ....\glue(\leftskip) 60.22499
 ....\hbox(0.0+0.0)x0.0
-....\rule(15.45767+6.6248)x0.0
+....\rule(14.05243+6.02255)x0.0
 ....\hbox(8.14243+0.16861)x0.0, glue set - 36.135fil
 .....\glue 0.0 plus 1.0fil minus 1.0fil
 .....\hbox(8.14243+0.16861)x36.135
@@ -1216,7 +1216,62 @@ Completed box being shipped out [1]
 ....\TU/FandolSong(0)/m/n/12.045 式
 ....\kern -0.00017
 ....\kern 0.00017
-....\rule(15.45767+6.6248)x0.0
+....\rule(14.05243+6.02255)x0.0
+....\kern 0.0
+....\glue 2.00749
+....\glue -4.015
+....\glue 3.01125
+....\leaders 0.0 plus 1.0fill
+.....\hbox(1.2045+0.13248)x4.015, glue set 1.00375fil
+......\glue 0.0 plus 1.0fil minus 1.0fil
+......\hbox(1.2045+0.13248)x3.01125
+.......\special{color push  Black}
+.......\TU/texgyretermes(0)/m/n/12.045 .
+.......\kern -0.0002
+.......\kern 0.0002
+.......\special{color pop}
+....\kern 0.0
+....\glue 2.00749
+....\TU/texgyretermes(0)/m/n/12.045 6
+....\kern -0.0002
+....\kern 0.0002
+....\penalty 10000
+....\glue(\parfillskip) 0.0 plus 1.0fil
+....\glue(\rightskip) 0.0
+...\penalty 10000
+...\glue 12.045
+...\glue -18.045
+...\penalty -300
+...\glue 6.0
+...\glue 12.045
+...\glue 0.0 plus 0.1
+...\penalty 10000
+...\glue(\parskip) 0.0
+...\glue(\parskip) 0.0
+...\glue(\baselineskip) 0.00002
+...\hbox(14.05243+6.02255)x417.11752, glue set 335.8138fill
+....\glue(\leftskip) 48.18
+....\hbox(0.0+0.0)x0.0
+....\rule(14.05243+6.02255)x0.0
+....\hbox(9.35896+2.21626)x0.0, glue set - 48.18fil
+.....\glue 0.0 plus 1.0fil minus 1.0fil
+.....\hbox(9.35896+2.21626)x48.18
+......\special{color push  Black}
+......\TU/FandolSong(0)/m/n/12.045 第
+......\glue 3.01125 plus 1.50562 minus 1.00374
+......\TU/texgyretermes(0)/m/n/12.045 3
+......\glue 3.01125 plus 1.50562 minus 1.00374
+......\TU/FandolSong(0)/m/n/12.045 章
+......\kern -0.00017
+......\kern 0.00017
+......\glue 12.045
+......\special{color pop}
+....\TU/FandolSong(0)/m/n/12.045 引
+....\glue 0.0 plus 0.61353
+....\TU/FandolSong(0)/m/n/12.045 用
+....\kern -0.00017
+....\kern 0.00017
+....\rule(14.05243+6.02255)x0.0
 ....\kern 0.0
 ....\glue 2.00749
 ....\glue -4.015
@@ -1241,7 +1296,7 @@ Completed box being shipped out [1]
 ...\penalty 10000
 ...\glue 12.045
 ...\glue -18.045
-...\penalty -300
+...\penalty 0
 ...\glue 6.0
 ...\glue 12.045
 ...\glue 0.0 plus 0.1
@@ -1249,29 +1304,19 @@ Completed box being shipped out [1]
 ...\glue(\parskip) 0.0
 ...\glue(\parskip) 0.0
 ...\glue(\baselineskip) 0.00002
-...\hbox(15.45767+6.6248)x417.11752, glue set 335.8138fill
-....\glue(\leftskip) 48.18
+...\hbox(14.05243+6.02255)x417.11752, glue set 359.9038fill
 ....\hbox(0.0+0.0)x0.0
-....\rule(15.45767+6.6248)x0.0
-....\hbox(9.35896+2.21626)x0.0, glue set - 48.18fil
-.....\glue 0.0 plus 1.0fil minus 1.0fil
-.....\hbox(9.35896+2.21626)x48.18
-......\special{color push  Black}
-......\TU/FandolSong(0)/m/n/12.045 第
-......\glue 3.01125 plus 1.50562 minus 1.00374
-......\TU/texgyretermes(0)/m/n/12.045 3
-......\glue 3.01125 plus 1.50562 minus 1.00374
-......\TU/FandolSong(0)/m/n/12.045 章
-......\kern -0.00017
-......\kern 0.00017
-......\glue 12.045
-......\special{color pop}
-....\TU/FandolSong(0)/m/n/12.045 引
+....\rule(14.05243+6.02255)x0.0
+....\TU/FandolSong(0)/m/n/12.045 参
 ....\glue 0.0 plus 0.61353
-....\TU/FandolSong(0)/m/n/12.045 用
+....\TU/FandolSong(0)/m/n/12.045 考
+....\glue 0.0 plus 0.61353
+....\TU/FandolSong(0)/m/n/12.045 文
+....\glue 0.0 plus 0.61353
+....\TU/FandolSong(0)/m/n/12.045 献
 ....\kern -0.00017
 ....\kern 0.00017
-....\rule(15.45767+6.6248)x0.0
+....\rule(14.05243+6.02255)x0.0
 ....\kern 0.0
 ....\glue 2.00749
 ....\glue -4.015
@@ -1294,29 +1339,39 @@ Completed box being shipped out [1]
 ....\glue(\parfillskip) 0.0 plus 1.0fil
 ....\glue(\rightskip) 0.0
 ...\penalty 10000
-...\glue 12.045
-...\glue -18.045
 ...\penalty 0
-...\glue 6.0
-...\glue 12.045
 ...\glue 0.0 plus 0.1
 ...\penalty 10000
 ...\glue(\parskip) 0.0
 ...\glue(\parskip) 0.0
 ...\glue(\baselineskip) 0.00002
-...\hbox(15.45767+6.6248)x417.11752, glue set 359.9038fill
+...\hbox(14.05243+6.02255)x417.11752, glue set 312.06107fill
+....\glue(\leftskip) 47.84273
 ....\hbox(0.0+0.0)x0.0
-....\rule(15.45767+6.6248)x0.0
-....\TU/FandolSong(0)/m/n/12.045 参
+....\rule(14.05243+6.02255)x0.0
+....\hbox(9.14215+1.99945)x0.0, glue set - 47.84273fil
+.....\glue 0.0 plus 1.0fil minus 1.0fil
+.....\hbox(9.14215+1.99945)x47.84273
+......\special{color push  Black}
+......\TU/FandolSong(0)/m/n/12.045 附
+......\glue 0.0 plus 0.61353
+......\TU/FandolSong(0)/m/n/12.045 录
+......\glue 3.01125 plus 1.5041 minus 1.00473
+......\TU/texgyretermes(0)/m/n/12.045 A
+......\kern -0.0002
+......\kern 0.0002
+......\glue 12.045
+......\special{color pop}
+....\TU/FandolSong(0)/m/n/12.045 附
 ....\glue 0.0 plus 0.61353
-....\TU/FandolSong(0)/m/n/12.045 考
+....\TU/FandolSong(0)/m/n/12.045 录
 ....\glue 0.0 plus 0.61353
-....\TU/FandolSong(0)/m/n/12.045 文
+....\TU/FandolSong(0)/m/n/12.045 章
 ....\glue 0.0 plus 0.61353
-....\TU/FandolSong(0)/m/n/12.045 献
+....\TU/FandolSong(0)/m/n/12.045 节
 ....\kern -0.00017
 ....\kern 0.00017
-....\rule(15.45767+6.6248)x0.0
+....\rule(14.05243+6.02255)x0.0
 ....\kern 0.0
 ....\glue 2.00749
 ....\glue -4.015
@@ -1345,33 +1400,15 @@ Completed box being shipped out [1]
 ...\glue(\parskip) 0.0
 ...\glue(\parskip) 0.0
 ...\glue(\baselineskip) 0.00002
-...\hbox(15.45767+6.6248)x417.11752, glue set 306.03857fill
-....\glue(\leftskip) 47.84273
+...\hbox(14.05243+6.02255)x417.11752, glue set 377.9713fill
 ....\hbox(0.0+0.0)x0.0
-....\rule(15.45767+6.6248)x0.0
-....\hbox(9.14215+1.99945)x0.0, glue set - 47.84273fil
-.....\glue 0.0 plus 1.0fil minus 1.0fil
-.....\hbox(9.14215+1.99945)x47.84273
-......\special{color push  Black}
-......\TU/FandolSong(0)/m/n/12.045 附
-......\glue 0.0 plus 0.61353
-......\TU/FandolSong(0)/m/n/12.045 录
-......\glue 3.01125 plus 1.5041 minus 1.00473
-......\TU/texgyretermes(0)/m/n/12.045 A
-......\kern -0.0002
-......\kern 0.0002
-......\glue 12.045
-......\special{color pop}
-....\TU/FandolSong(0)/m/n/12.045 附
+....\rule(14.05243+6.02255)x0.0
+....\TU/FandolSong(0)/m/n/12.045 致
 ....\glue 0.0 plus 0.61353
-....\TU/FandolSong(0)/m/n/12.045 录
-....\glue 0.0 plus 0.61353
-....\TU/FandolSong(0)/m/n/12.045 章
-....\glue 0.0 plus 0.61353
-....\TU/FandolSong(0)/m/n/12.045 节
+....\TU/FandolSong(0)/m/n/12.045 谢
 ....\kern -0.00017
 ....\kern 0.00017
-....\rule(15.45767+6.6248)x0.0
+....\rule(14.05243+6.02255)x0.0
 ....\kern 0.0
 ....\glue 2.00749
 ....\glue -4.015
@@ -1394,54 +1431,17 @@ Completed box being shipped out [1]
 ....\glue(\parfillskip) 0.0 plus 1.0fil
 ....\glue(\rightskip) 0.0
 ...\penalty 10000
-...\penalty 0
-...\glue 0.0 plus 0.1
-...\penalty 10000
-...\glue(\parskip) 0.0
-...\glue(\parskip) 0.0
-...\glue(\baselineskip) 0.00002
-...\hbox(15.45767+6.6248)x417.11752, glue set 377.9713fill
-....\hbox(0.0+0.0)x0.0
-....\rule(15.45767+6.6248)x0.0
-....\TU/FandolSong(0)/m/n/12.045 致
-....\glue 0.0 plus 0.61353
-....\TU/FandolSong(0)/m/n/12.045 谢
-....\kern -0.00017
-....\kern 0.00017
-....\rule(15.45767+6.6248)x0.0
-....\kern 0.0
-....\glue 2.00749
-....\glue -4.015
-....\glue 3.01125
-....\leaders 0.0 plus 1.0fill
-.....\hbox(1.2045+0.13248)x4.015, glue set 1.00375fil
-......\glue 0.0 plus 1.0fil minus 1.0fil
-......\hbox(1.2045+0.13248)x3.01125
-.......\special{color push  Black}
-.......\TU/texgyretermes(0)/m/n/12.045 .
-.......\kern -0.0002
-.......\kern 0.0002
-.......\special{color pop}
-....\kern 0.0
-....\glue 2.00749
-....\TU/texgyretermes(0)/m/n/12.045 11
-....\kern -0.0002
-....\kern 0.0002
-....\penalty 10000
-....\glue(\parfillskip) 0.0 plus 1.0fil
-....\glue(\rightskip) 0.0
-...\penalty 10000
 ...\glue 0.0 plus 1.0fil
 ...\glue 0.0
 ...\glue 0.0 plus 0.0001fil
-..\glue(\baselineskip) 7.63202
-..\hbox(14.84546+3.5232)x417.11752
+..\glue(\baselineskip) 8.23427
+..\hbox(14.24321+3.5232)x417.11752
 ...\special{color push  Black}
-...\hbox(14.84546+3.5232)x417.11752
-....\hbox(14.84546+3.5232)x417.11752
-.....\vbox(14.84546+3.5232)x417.11752
+...\hbox(14.24321+3.5232)x417.11752
+....\hbox(14.24321+3.5232)x417.11752
+.....\vbox(14.24321+3.5232)x417.11752
 ......\rule(0.0+0.0)x417.11752
-......\glue 6.6248
+......\glue 6.02255
 ......\hbox(8.22066+3.5232)x417.11752
 .......\hbox(0.0+0.0)x0.0, glue set - 417.11752fil
 ........\vbox(0.0+0.0)x417.11752
@@ -1554,7 +1554,7 @@ Completed box being shipped out [2]
 ....\special{color pop}
 ..\glue 15.6491
 ..\glue(\lineskip) 0.0
-..\vbox(700.50723+0.0)x417.11752, glue set 578.43443fil
+..\vbox(700.50723+0.0)x417.11752, glue set 583.05118fil
 ...\write-{}
 ...\write-{}
 ...\glue(\topskip) 12.0
@@ -1591,11 +1591,11 @@ Completed box being shipped out [2]
 ...\penalty 10000
 ...\glue(\parskip) 0.0
 ...\glue(\parskip) 0.0
-...\glue(\baselineskip) 3.33655
-...\hbox(15.45767+6.6248)x417.11752, glue set 269.56631fill
+...\glue(\baselineskip) 2.7343
+...\hbox(14.05243+6.02255)x417.11752, glue set 269.56631fill
 ....\glue(\leftskip) 42.15749
 ....\hbox(0.0+0.0)x0.0
-....\rule(15.45767+6.6248)x0.0
+....\rule(14.05243+6.02255)x0.0
 ....\hbox(8.84103+1.73447)x0.0, glue set - 42.15749fil
 .....\glue 0.0 plus 1.0fil minus 1.0fil
 .....\hbox(8.84103+1.73447)x42.15749
@@ -1627,7 +1627,7 @@ Completed box being shipped out [2]
 ....\TU/FandolSong(0)/m/n/12.045 方
 ....\kern -0.00017
 ....\kern 0.00017
-....\rule(15.45767+6.6248)x0.0
+....\rule(14.05243+6.02255)x0.0
 ....\kern 0.0
 ....\glue 2.00749
 ....\glue -4.015
@@ -1656,10 +1656,10 @@ Completed box being shipped out [2]
 ...\glue(\parskip) 0.0
 ...\glue(\parskip) 0.0
 ...\glue(\baselineskip) 0.00002
-...\hbox(15.45767+6.6248)x417.11752, glue set 269.56631fill
+...\hbox(14.05243+6.02255)x417.11752, glue set 269.56631fill
 ....\glue(\leftskip) 42.15749
 ....\hbox(0.0+0.0)x0.0
-....\rule(15.45767+6.6248)x0.0
+....\rule(14.05243+6.02255)x0.0
 ....\hbox(9.31079+2.09581)x0.0, glue set - 42.15749fil
 .....\glue 0.0 plus 1.0fil minus 1.0fil
 .....\hbox(9.31079+2.09581)x42.15749
@@ -1691,7 +1691,7 @@ Completed box being shipped out [2]
 ....\TU/FandolSong(0)/m/n/12.045 方
 ....\kern -0.00017
 ....\kern 0.00017
-....\rule(15.45767+6.6248)x0.0
+....\rule(14.05243+6.02255)x0.0
 ....\kern 0.0
 ....\glue 2.00749
 ....\glue -4.015
@@ -1717,15 +1717,15 @@ Completed box being shipped out [2]
 ...\glue 0.0 plus 1.0fil
 ...\glue 0.0
 ...\glue 0.0 plus 0.0001fil
-..\glue(\baselineskip) 7.63202
-..\hbox(14.84546+3.5232)x417.11752
+..\glue(\baselineskip) 8.23427
+..\hbox(14.24321+3.5232)x417.11752
 ...\special{color push  Black}
-...\hbox(14.84546+3.5232)x417.11752
+...\hbox(14.24321+3.5232)x417.11752
 ....\glue 0.0 plus 1.0fil minus 1.0fil
-....\hbox(14.84546+3.5232)x417.11752
-.....\vbox(14.84546+3.5232)x417.11752
+....\hbox(14.24321+3.5232)x417.11752
+.....\vbox(14.24321+3.5232)x417.11752
 ......\rule(0.0+0.0)x417.11752
-......\glue 6.6248
+......\glue 6.02255
 ......\hbox(8.22066+3.5232)x417.11752
 .......\hbox(0.0+0.0)x0.0, glue set - 417.11752fil
 ........\vbox(0.0+0.0)x417.11752
@@ -1833,7 +1833,7 @@ Completed box being shipped out [3]
 ....\special{color pop}
 ..\glue 15.6491
 ..\glue(\lineskip) 0.0
-..\vbox(700.50723+0.0)x417.11752, glue set 607.0062fil
+..\vbox(700.50723+0.0)x417.11752, glue set 609.01347fil
 ...\write-{}
 ...\write-{}
 ...\glue(\topskip) 12.0
@@ -1862,7 +1862,7 @@ Completed box being shipped out [3]
 ...\glue 19.07124
 ...\glue(\parskip) 0.0
 ...\glue(\parskip) 0.0
-...\glue(\baselineskip) 10.96498
+...\glue(\baselineskip) 8.95749
 ...\hbox(7.97379+0.13248)x417.11752, glue set 339.3992fil
 ....\hbox(0.0+0.0)x24.09
 ....\TU/texgyretermes(0)/m/n/12.045 Notations.
@@ -1873,14 +1873,14 @@ Completed box being shipped out [3]
 ...\glue 0.0 plus 1.0fil
 ...\glue 0.0
 ...\glue 0.0 plus 0.0001fil
-..\glue(\baselineskip) 7.63202
-..\hbox(14.84546+3.5232)x417.11752
+..\glue(\baselineskip) 8.23427
+..\hbox(14.24321+3.5232)x417.11752
 ...\special{color push  Black}
-...\hbox(14.84546+3.5232)x417.11752
-....\hbox(14.84546+3.5232)x417.11752
-.....\vbox(14.84546+3.5232)x417.11752
+...\hbox(14.24321+3.5232)x417.11752
+....\hbox(14.24321+3.5232)x417.11752
+.....\vbox(14.24321+3.5232)x417.11752
 ......\rule(0.0+0.0)x417.11752
-......\glue 6.6248
+......\glue 6.02255
 ......\hbox(8.22066+3.5232)x417.11752
 .......\hbox(0.0+0.0)x0.0, glue set - 417.11752fil
 ........\vbox(0.0+0.0)x417.11752
@@ -1990,7 +1990,7 @@ Completed box being shipped out [4]
 ....\special{color pop}
 ..\glue 15.6491
 ..\glue(\lineskip) 0.0
-..\vbox(700.50723+0.0)x417.11752, glue set 242.33476fil
+..\vbox(700.50723+0.0)x417.11752, glue set 268.42937fil
 ...\write-{}
 ...\write-{}
 ...\write2{\@writefile{toc}{\protect \addvspace {12bp}}}
@@ -2026,7 +2026,7 @@ Completed box being shipped out [4]
 ...\glue 19.07124
 ...\glue(\parskip) 0.0
 ...\glue(\parskip) 0.0
-...\glue(\baselineskip) 9.84479
+...\glue(\baselineskip) 7.8373
 ...\hbox(9.3951+2.32468)x417.11752, glue set 0.41225
 ....\hbox(0.0+0.0)x24.09
 ....\TU/FandolSong(0)/m/n/12.045 研
@@ -2096,7 +2096,7 @@ Completed box being shipped out [4]
 ....\TU/FandolSong(0)/m/n/12.045 依
 ....\glue(\rightskip) 0.0
 ...\penalty 10000
-...\glue(\baselineskip) 10.36272
+...\glue(\baselineskip) 8.35522
 ...\hbox(9.3951+2.32468)x417.11752, glue set - 0.2467
 ....\TU/FandolSong(0)/m/n/12.045 据
 ....\penalty 10000
@@ -2174,7 +2174,7 @@ Completed box being shipped out [4]
 ....\glue 0.0 plus 0.61353
 ....\TU/FandolSong(0)/m/n/12.045 提
 ....\glue(\rightskip) 0.0
-...\glue(\baselineskip) 10.35066
+...\glue(\baselineskip) 8.34317
 ...\hbox(9.40715+2.32468)x417.11752, glue set 0.38647
 ....\TU/FandolSong(0)/m/n/12.045 高
 ....\glue 0.0 plus 0.61353
@@ -2246,7 +2246,7 @@ Completed box being shipped out [4]
 ....\glue 0.0 plus 0.61353
 ....\TU/FandolSong(0)/m/n/12.045 同
 ....\glue(\rightskip) 0.0
-...\glue(\baselineskip) 10.36272
+...\glue(\baselineskip) 8.35522
 ...\hbox(9.3951+2.32468)x417.11752, glue set - 0.37006
 ....\TU/FandolSong(0)/m/n/12.045 努
 ....\glue 0.0 plus 0.61353
@@ -2323,7 +2323,7 @@ Completed box being shipped out [4]
 ....\TU/FandolSong(0)/m/n/12.045 问
 ....\glue(\rightskip) 0.0
 ...\penalty 150
-...\glue(\baselineskip) 10.31453
+...\glue(\baselineskip) 8.30704
 ...\hbox(9.44328+2.32468)x417.11752, glue set 135.79454fil
 ....\TU/FandolSong(0)/m/n/12.045 题
 ....\glue 0.0 plus 0.61353
@@ -2429,7 +2429,7 @@ Completed box being shipped out [4]
 ...\glue 6.02249
 ...\glue(\parskip) 0.0
 ...\glue(\parskip) 0.0
-...\glue(\baselineskip) 10.02245
+...\glue(\baselineskip) 8.01495
 ...\hbox(9.3951+2.32468)x417.11752, glue set 0.41225
 ....\hbox(0.0+0.0)x24.09
 ....\TU/FandolSong(0)/m/n/12.045 从
@@ -2499,7 +2499,7 @@ Completed box being shipped out [4]
 ....\TU/FandolSong(0)/m/n/12.045 这
 ....\glue(\rightskip) 0.0
 ...\penalty 10150
-...\glue(\baselineskip) 10.41089
+...\glue(\baselineskip) 8.4034
 ...\hbox(9.34692+2.16809)x417.11752, glue set 220.10953fil
 ....\TU/FandolSong(0)/m/n/12.045 两
 ....\glue 0.0 plus 0.61353
@@ -2574,7 +2574,7 @@ Completed box being shipped out [4]
 ...\glue 6.02249
 ...\glue(\parskip) 0.0
 ...\glue(\parskip) 0.0
-...\glue(\baselineskip) 10.31453
+...\glue(\baselineskip) 8.30704
 ...\hbox(9.40715+2.32468)x417.11752, glue set 0.42645
 ....\hbox(0.0+0.0)x24.09
 ....\TU/FandolSong(0)/m/n/12.045 文
@@ -2646,7 +2646,7 @@ Completed box being shipped out [4]
 ....\TU/FandolSong(0)/m/n/12.045 何
 ....\glue(\rightskip) 0.0
 ...\penalty 10000
-...\glue(\baselineskip) 10.35066
+...\glue(\baselineskip) 8.34317
 ...\hbox(9.40715+2.32468)x417.11752, glue set 0.17856
 ....\TU/FandolSong(0)/m/n/12.045 写
 ....\penalty 10000
@@ -2723,7 +2723,7 @@ Completed box being shipped out [4]
 ....\TU/FandolSong(0)/m/n/12.045 、
 ....\rule(0.0+0.0)x-7.85333
 ....\glue(\rightskip) 0.0
-...\glue(\baselineskip) 10.33862
+...\glue(\baselineskip) 8.33113
 ...\hbox(9.41919+2.32468)x417.11752, glue set - 0.33904
 ....\TU/FandolSong(0)/m/n/12.045 缩
 ....\glue 0.0 plus 0.61353
@@ -2806,7 +2806,7 @@ Completed box being shipped out [4]
 ....\TU/FandolSong(0)/m/n/12.045 ，
 ....\rule(0.0+0.0)x-8.33514
 ....\glue(\rightskip) 0.0
-...\glue(\baselineskip) 10.38681
+...\glue(\baselineskip) 8.37932
 ...\hbox(9.371+2.32468)x417.11752, glue set 0.1969
 ....\TU/FandolSong(0)/m/n/12.045 方
 ....\glue 0.0 plus 0.61353
@@ -2881,7 +2881,7 @@ Completed box being shipped out [4]
 ....\TU/FandolSong(0)/m/n/12.045 ；
 ....\rule(0.0+0.0)x-8.32309
 ....\glue(\rightskip) 0.0
-...\glue(\baselineskip) 10.36272
+...\glue(\baselineskip) 8.35522
 ...\hbox(9.3951+2.32468)x417.11752, glue set - 0.37006
 ....\TU/FandolSong(0)/m/n/12.045 有
 ....\glue 0.0 plus 0.61353
@@ -2958,7 +2958,7 @@ Completed box being shipped out [4]
 ....\TU/FandolSong(0)/m/n/12.045 段
 ....\glue(\rightskip) 0.0
 ...\penalty 150
-...\glue(\baselineskip) 10.33862
+...\glue(\baselineskip) 8.33113
 ...\hbox(9.41919+1.98741)x417.11752, glue set 352.6045fil
 ....\TU/FandolSong(0)/m/n/12.045 的
 ....\glue 0.0 plus 0.61353
@@ -2982,15 +2982,15 @@ Completed box being shipped out [4]
 ...\glue 0.0 plus 1.0fil
 ...\glue 0.0
 ...\glue 0.0 plus 0.0001fil
-..\glue(\baselineskip) 7.63202
-..\hbox(14.84546+3.5232)x417.11752
+..\glue(\baselineskip) 8.23427
+..\hbox(14.24321+3.5232)x417.11752
 ...\special{color push  Black}
-...\hbox(14.84546+3.5232)x417.11752
+...\hbox(14.24321+3.5232)x417.11752
 ....\glue 0.0 plus 1.0fil minus 1.0fil
-....\hbox(14.84546+3.5232)x417.11752
-.....\vbox(14.84546+3.5232)x417.11752
+....\hbox(14.24321+3.5232)x417.11752
+.....\vbox(14.24321+3.5232)x417.11752
 ......\rule(0.0+0.0)x417.11752
-......\glue 6.6248
+......\glue 6.02255
 ......\hbox(8.22066+3.5232)x417.11752
 .......\hbox(0.0+0.0)x0.0, glue set - 417.11752fil
 ........\vbox(0.0+0.0)x417.11752
@@ -3125,7 +3125,7 @@ Completed box being shipped out [5]
 ....\special{color pop}
 ..\glue 15.6491
 ..\glue(\lineskip) 0.0
-..\vbox(700.50723+0.0)x417.11752, glue set >20000.0fil
+..\vbox(700.50723+0.0)x417.11752, glue set 6.00505fil
 ...\write-{}
 ...\write2{\@writefile{toc}{\protect \addvspace {12bp}}}
 ...\write2{\pp@pagectr{footnote}{2}{\theabspage }{\thepage }}
@@ -3202,7 +3202,7 @@ Completed box being shipped out [5]
 ...\glue 6.02249
 ...\glue(\parskip) 0.0
 ...\glue(\parskip) 0.0
-...\glue(\baselineskip) 9.94115
+...\glue(\baselineskip) 7.93365
 ...\hbox(9.43123+2.32468)x417.11752, glue set - 0.2467
 ....\hbox(0.0+0.0)x24.09
 ....\TU/FandolSong(0)/m/n/12.045 图
@@ -3278,7 +3278,7 @@ Completed box being shipped out [5]
 ....\TU/FandolSong(0)/m/n/12.045 序
 ....\glue(\rightskip) 0.0
 ...\penalty 10000
-...\glue(\baselineskip) 10.32658
+...\glue(\baselineskip) 8.31909
 ...\hbox(9.43123+2.32468)x417.11752, glue set - 0.24803
 ....\TU/FandolSong(0)/m/n/12.045 号
 ....\penalty 10000
@@ -3364,7 +3364,7 @@ Completed box being shipped out [5]
 ....\TU/FandolSong(0)/m/n/12.045 连
 ....\glue(\rightskip) 0.0
 ...\penalty 150
-...\glue(\baselineskip) 10.12181
+...\glue(\baselineskip) 8.11432
 ...\hbox(9.636+2.40898)x417.11752, glue set 156.87334fil
 ....\TU/FandolSong(0)/m/n/12.045 接
 ....\penalty 10000
@@ -3479,7 +3479,7 @@ Completed box being shipped out [5]
 ...\glue 6.02249
 ...\glue(\parskip) 0.0
 ...\glue(\parskip) 0.0
-...\glue(\baselineskip) 10.44101
+...\glue(\baselineskip) 8.43352
 ...\hbox(9.40715+2.15604)x417.11752, glue set 220.10953fil
 ....\hbox(0.0+0.0)x24.09
 ....\TU/FandolSong(0)/m/n/12.045 插
@@ -3526,9 +3526,9 @@ Completed box being shipped out [5]
 ...\penalty 0
 ...\glue 10.03749
 ...\glue 0.0
-...\vbox(225.50859+0.0)x417.11752
+...\vbox(217.47862+0.0)x417.11752
 ....\special{color push  Black}
-....\vbox(225.50859+0.0)x417.11752
+....\vbox(217.47862+0.0)x417.11752
 .....\hbox(125.13368+0.0)x417.11752, glue set 145.99051fil
 ......\glue(\leftskip) 0.0 plus 1.0fil
 ......\hbox(0.0+0.0)x0.0
@@ -3554,11 +3554,11 @@ Completed box being shipped out [5]
 .....\glue 6.02249
 .....\glue(\parskip) 0.0
 .....\glue(\parskip) 0.0
-.....\hbox(15.45767+6.6248)x417.11752
+.....\hbox(14.05243+6.02255)x417.11752
 ......\hbox(0.0+0.0)x0.0
 ......\glue 0.0
-......\vbox(15.45767+6.6248)x417.11752
-.......\hbox(15.45767+6.6248)x417.11752, glue set 139.30003fil
+......\vbox(14.05243+6.02255)x417.11752
+.......\hbox(14.05243+6.02255)x417.11752, glue set 139.30003fil
 ........\glue(\leftskip) 0.0 plus 1.0fil
 ........\hbox(0.0+0.0)x0.0
 ........\TU/FandolSong(0)/m/n/12.045 图
@@ -3570,7 +3570,7 @@ Completed box being shipped out [5]
 ........\kern -0.0002
 ........\kern 0.0002
 ........\glue 12.045
-........\rule(15.45767+*)x0.0
+........\rule(14.05243+*)x0.0
 ........\penalty 10000
 ........\glue 0.0
 ........\TU/FandolSong(0)/m/n/12.045 图
@@ -3591,7 +3591,7 @@ Completed box being shipped out [5]
 ........\kern -0.00017
 ........\kern 0.00017
 ........\penalty 10000
-........\rule(0.0+6.6248)x0.0
+........\rule(0.0+6.02255)x0.0
 ........\penalty 10000
 ........\glue(\parfillskip) 0.0
 ........\glue(\rightskip) 0.0 plus 1.0fil
@@ -3607,14 +3607,14 @@ Completed box being shipped out [5]
 .....\glue 6.02249
 .....\glue(\parskip) 0.0
 .....\glue(\parskip) 0.0
-.....\hbox(59.62265+6.6248)x417.11752
+.....\hbox(54.20242+6.02255)x417.11752
 ......\hbox(0.0+0.0)x0.0
 ......\glue 21.07874
-......\vbox(59.62265+6.6248)x396.03879
-.......\hbox(15.45767+2.32468)x396.03879, glue set - 0.08005
+......\vbox(54.20242+6.02255)x396.03879
+.......\hbox(14.05243+2.32468)x396.03879, glue set - 0.08005
 ........\glue(\leftskip) 0.0 plus 1.0fil
 ........\hbox(0.0+0.0)x0.0
-........\rule(15.45767+*)x0.0
+........\rule(14.05243+*)x0.0
 ........\penalty 10000
 ........\glue 0.0
 ........\TU/FandolSong(0)/m/n/12.045 若
@@ -3690,7 +3690,7 @@ Completed box being shipped out [5]
 ........\TU/FandolSong(0)/m/n/12.045 标
 ........\glue(\rightskip) 0.0 plus -1.0fil
 .......\penalty 10000
-.......\glue(\baselineskip) 10.35066
+.......\glue(\baselineskip) 8.34317
 .......\hbox(9.40715+2.32468)x396.03879, glue set - 0.12006
 ........\glue(\leftskip) 0.0 plus 1.0fil
 ........\TU/FandolSong(0)/m/n/12.045 点
@@ -3764,8 +3764,8 @@ Completed box being shipped out [5]
 ........\TU/FandolSong(0)/m/n/12.045 注
 ........\glue(\rightskip) 0.0 plus -1.0fil
 .......\penalty 150
-.......\glue(\baselineskip) 10.36272
-.......\hbox(9.3951+6.6248)x396.03879, glue set 27.2454fil
+.......\glue(\baselineskip) 8.35522
+.......\hbox(9.3951+6.02255)x396.03879, glue set 27.2454fil
 ........\glue(\leftskip) 0.0 plus 1.0fil
 ........\TU/FandolSong(0)/m/n/12.045 文
 ........\glue 0.0 plus 0.75479
@@ -3832,7 +3832,7 @@ Completed box being shipped out [5]
 ........\kern -0.18753
 ........\kern 0.18753
 ........\penalty 10000
-........\rule(0.0+6.6248)x0.0
+........\rule(0.0+6.02255)x0.0
 ........\penalty 10000
 ........\glue(\parfillskip) 0.0 plus 2.0fil
 ........\glue(\rightskip) 0.0 plus -1.0fil
@@ -3937,7 +3937,7 @@ Completed box being shipped out [5]
 ...\glue 6.02249
 ...\glue(\parskip) 0.0
 ...\glue(\parskip) 0.0
-...\glue(\baselineskip) 10.1459
+...\glue(\baselineskip) 8.13841
 ...\hbox(9.40715+2.15604)x417.11752, glue set 220.10953fil
 ....\hbox(0.0+0.0)x24.09
 ....\TU/FandolSong(0)/m/n/12.045 表
@@ -3984,19 +3984,19 @@ Completed box being shipped out [5]
 ...\penalty 0
 ...\glue 10.03749
 ...\glue 0.0
-...\vbox(124.22385+0.0)x417.11752
+...\vbox(122.21635+0.0)x417.11752
 ....\special{color push  Black}
-....\vbox(124.22385+0.0)x417.11752
+....\vbox(122.21635+0.0)x417.11752
 .....\write2{\@writefile{lot}{\protect \contentsline {table}{\protect \numberline {2.1}{\ignorespaces 表题置于表的上方}}{\thepage }{}\protected@file@percent }}
 .....\special{color push  Black}
 .....\glue 0.0
 .....\glue(\parskip) 0.0
 .....\glue(\parskip) 0.0
-.....\hbox(15.45767+6.6248)x417.11752
+.....\hbox(14.05243+6.02255)x417.11752
 ......\hbox(0.0+0.0)x0.0
 ......\glue 0.0
-......\vbox(15.45767+6.6248)x417.11752
-.......\hbox(15.45767+6.6248)x417.11752, glue set 139.30003fil
+......\vbox(14.05243+6.02255)x417.11752
+.......\hbox(14.05243+6.02255)x417.11752, glue set 139.30003fil
 ........\glue(\leftskip) 0.0 plus 1.0fil
 ........\hbox(0.0+0.0)x0.0
 ........\TU/FandolSong(0)/m/n/12.045 表
@@ -4008,7 +4008,7 @@ Completed box being shipped out [5]
 ........\kern -0.0002
 ........\kern 0.0002
 ........\glue 12.045
-........\rule(15.45767+*)x0.0
+........\rule(14.05243+*)x0.0
 ........\penalty 10000
 ........\glue 0.0
 ........\TU/FandolSong(0)/m/n/12.045 表
@@ -4029,7 +4029,7 @@ Completed box being shipped out [5]
 ........\kern -0.00017
 ........\kern 0.00017
 ........\penalty 10000
-........\rule(0.0+6.6248)x0.0
+........\rule(0.0+6.02255)x0.0
 ........\penalty 10000
 ........\glue(\parfillskip) 0.0
 ........\glue(\rightskip) 0.0 plus 1.0fil
@@ -4289,16 +4289,87 @@ Completed box being shipped out [5]
 ......\glue(\rightskip) 0.0 plus 1.0fil
 .....\glue 0.0
 ....\special{color pop}
+...\penalty 0
+...\penalty 10000
+...\glue 10.03749
+...\glue(\parskip) 0.0
+...\glue(\parskip) 0.0
+...\hbox(9.40715+2.32468)x417.11752, glue set 75.56955fil
+....\hbox(0.0+0.0)x24.09
+....\TU/FandolSong(0)/m/n/12.045 不
+....\glue 0.0 plus 0.61353
+....\TU/FandolSong(0)/m/n/12.045 宜
+....\glue 0.0 plus 0.61353
+....\TU/FandolSong(0)/m/n/12.045 将
+....\glue 0.0 plus 0.61353
+....\TU/FandolSong(0)/m/n/12.045 多
+....\glue 0.0 plus 0.61353
+....\TU/FandolSong(0)/m/n/12.045 个
+....\glue 0.0 plus 0.61353
+....\TU/FandolSong(0)/m/n/12.045 表
+....\glue 0.0 plus 0.61353
+....\TU/FandolSong(0)/m/n/12.045 格
+....\glue 0.0 plus 0.61353
+....\TU/FandolSong(0)/m/n/12.045 连
+....\glue 0.0 plus 0.61353
+....\TU/FandolSong(0)/m/n/12.045 续
+....\glue 0.0 plus 0.61353
+....\TU/FandolSong(0)/m/n/12.045 排
+....\glue 0.0 plus 0.61353
+....\TU/FandolSong(0)/m/n/12.045 版
+....\penalty 10000
+....\TU/FandolSong(0)/m/n/12.045 ，
+....\rule(0.0+0.0)x-8.33514
+....\glue 8.33514 minus 6.0225
+....\glue 0.0 plus 0.61353
+....\TU/FandolSong(0)/m/n/12.045 表
+....\glue 0.0 plus 0.61353
+....\TU/FandolSong(0)/m/n/12.045 格
+....\glue 0.0 plus 0.61353
+....\TU/FandolSong(0)/m/n/12.045 与
+....\glue 0.0 plus 0.61353
+....\TU/FandolSong(0)/m/n/12.045 文
+....\glue 0.0 plus 0.61353
+....\TU/FandolSong(0)/m/n/12.045 字
+....\glue 0.0 plus 0.61353
+....\TU/FandolSong(0)/m/n/12.045 论
+....\glue 0.0 plus 0.61353
+....\TU/FandolSong(0)/m/n/12.045 述
+....\glue 0.0 plus 0.61353
+....\TU/FandolSong(0)/m/n/12.045 段
+....\glue 0.0 plus 0.61353
+....\TU/FandolSong(0)/m/n/12.045 落
+....\glue 0.0 plus 0.61353
+....\TU/FandolSong(0)/m/n/12.045 应
+....\glue 0.0 plus 0.61353
+....\TU/FandolSong(0)/m/n/12.045 穿
+....\glue 0.0 plus 0.61353
+....\TU/FandolSong(0)/m/n/12.045 插
+....\glue 0.0 plus 0.61353
+....\TU/FandolSong(0)/m/n/12.045 排
+....\glue 0.0 plus 0.61353
+....\TU/FandolSong(0)/m/n/12.045 版
+....\penalty 10000
+....\TU/FandolSong(0)/m/n/12.045 。
+....\rule(0.0+0.0)x-7.75697
+....\kern 0.00047
+....\kern -0.00047
+....\kern -0.18753
+....\kern 0.18753
+....\penalty 10000
+....\glue(\parfillskip) 0.0 plus 1.0fil
+....\glue(\rightskip) 0.0
+...\glue 0.0 plus 1.0fil
 ...\glue 0.0
 ...\glue 0.0 plus 0.0001fil
-..\glue(\baselineskip) 7.63202
-..\hbox(14.84546+3.5232)x417.11752
+..\glue(\baselineskip) 8.23427
+..\hbox(14.24321+3.5232)x417.11752
 ...\special{color push  Black}
-...\hbox(14.84546+3.5232)x417.11752
-....\hbox(14.84546+3.5232)x417.11752
-.....\vbox(14.84546+3.5232)x417.11752
+...\hbox(14.24321+3.5232)x417.11752
+....\hbox(14.24321+3.5232)x417.11752
+.....\vbox(14.24321+3.5232)x417.11752
 ......\rule(0.0+0.0)x417.11752
-......\glue 6.6248
+......\glue 6.02255
 ......\hbox(8.22066+3.5232)x417.11752
 .......\hbox(0.0+0.0)x0.0, glue set - 417.11752fil
 ........\vbox(0.0+0.0)x417.11752
@@ -4332,6 +4403,26 @@ Completed box being shipped out [5]
 ..........\glue(\rightskip) 0.0
 ....\glue 0.0 plus 1.0fil minus 1.0fil
 ...\special{color pop}
+LaTeX Font Info:    Font shape `TU/XITSMath-Regular(1)/m/n' will be
+(Font)              scaled to size 9.03375pt on input line ....
+LaTeX Font Info:    Font shape `TU/XITSMath-Regular(1)/m/n' will be
+(Font)              scaled to size 7.227pt on input line ....
+LaTeX Font Info:    Font shape `TU/XITSMath-Regular(2)/m/n' will be
+(Font)              scaled to size 12.0461pt on input line ....
+LaTeX Font Info:    Font shape `TU/XITSMath-Regular(2)/m/n' will be
+(Font)              scaled to size 9.03458pt on input line ....
+LaTeX Font Info:    Font shape `TU/XITSMath-Regular(2)/m/n' will be
+(Font)              scaled to size 7.22766pt on input line ....
+LaTeX Font Info:    Font shape `TU/XITSMath-Regular(3)/m/n' will be
+(Font)              scaled to size 12.0437pt on input line ....
+LaTeX Font Info:    Font shape `TU/XITSMath-Regular(3)/m/n' will be
+(Font)              scaled to size 9.03278pt on input line ....
+LaTeX Font Info:    Font shape `TU/XITSMath-Regular(3)/m/n' will be
+(Font)              scaled to size 7.22623pt on input line ....
+LaTeX Font Info:    Font shape `TU/STIXTwoMath-Regular(0)/m/n' will be
+(Font)              scaled to size 8.59444pt on input line ....
+LaTeX Font Info:    Font shape `TU/STIXTwoMath-Regular(0)/m/n' will be
+(Font)              scaled to size 6.87555pt on input line ....
 Completed box being shipped out [6]
 \vbox(722.98453+3.5232)x435.04271
 .\glue -29.59128
@@ -4407,63 +4498,187 @@ Completed box being shipped out [6]
 ....\special{color pop}
 ..\glue 15.6491
 ..\glue(\lineskip) 0.0
-..\vbox(700.50723+0.0)x417.11752, glue set 686.10927fil
-...\glue(\topskip) 2.59285
-...\hbox(9.40715+2.32468)x417.11752, glue set 75.56955fil
+..\vbox(700.50723+0.0)x417.11752, glue set 607.82516fil
+...\write-{}
+...\glue(\topskip) 1.15147
+...\hbox(10.84853+2.52943)x417.11752, glue set 329.65482fil
+....\hbox(9.96321+0.21077)x45.30524
+.....\TU/texgyreheros(0)/m/n/14.05249 2.1.3
+.....\kern -0.0002
+.....\kern 0.0002
+.....\glue 14.05249
+....\TU/FandolHei(0)/m/n/14.05249 表
+....\glue 0.0 plus 0.87584
+....\TU/FandolHei(0)/m/n/14.05249 达
+....\glue 0.0 plus 0.87584
+....\TU/FandolHei(0)/m/n/14.05249 式
+....\kern -0.00017
+....\kern 0.00017
+....\penalty 10000
+....\glue(\parfillskip) 0.0 plus 1.0fil
+....\glue(\rightskip) 0.0
+...\write2{\@writefile{toc}{\protect \contentsline {subsection}{\protect \numberline {2.1.3}表达式}{\thepage }{}\protected@file@percent }}
+...\penalty 10000
+...\glue 6.02249
+...\glue(\parskip) 0.0
+...\glue(\parskip) 0.0
+...\glue(\baselineskip) 8.11433
+...\hbox(9.43123+2.21626)x417.11752, glue set 135.79454fil
 ....\hbox(0.0+0.0)x24.09
-....\TU/FandolSong(0)/m/n/12.045 不
-....\glue 0.0 plus 0.61353
-....\TU/FandolSong(0)/m/n/12.045 宜
-....\glue 0.0 plus 0.61353
-....\TU/FandolSong(0)/m/n/12.045 将
-....\glue 0.0 plus 0.61353
-....\TU/FandolSong(0)/m/n/12.045 多
-....\glue 0.0 plus 0.61353
-....\TU/FandolSong(0)/m/n/12.045 个
-....\glue 0.0 plus 0.61353
 ....\TU/FandolSong(0)/m/n/12.045 表
 ....\glue 0.0 plus 0.61353
-....\TU/FandolSong(0)/m/n/12.045 格
+....\TU/FandolSong(0)/m/n/12.045 达
+....\glue 0.0 plus 0.61353
+....\TU/FandolSong(0)/m/n/12.045 式
+....\glue 0.0 plus 0.61353
+....\TU/FandolSong(0)/m/n/12.045 主
+....\glue 0.0 plus 0.61353
+....\TU/FandolSong(0)/m/n/12.045 要
+....\glue 0.0 plus 0.61353
+....\TU/FandolSong(0)/m/n/12.045 是
+....\glue 0.0 plus 0.61353
+....\TU/FandolSong(0)/m/n/12.045 指
+....\glue 0.0 plus 0.61353
+....\TU/FandolSong(0)/m/n/12.045 分
+....\glue 0.0 plus 0.61353
+....\TU/FandolSong(0)/m/n/12.045 章
 ....\glue 0.0 plus 0.61353
 ....\TU/FandolSong(0)/m/n/12.045 连
 ....\glue 0.0 plus 0.61353
 ....\TU/FandolSong(0)/m/n/12.045 续
 ....\glue 0.0 plus 0.61353
-....\TU/FandolSong(0)/m/n/12.045 排
+....\TU/FandolSong(0)/m/n/12.045 编
 ....\glue 0.0 plus 0.61353
-....\TU/FandolSong(0)/m/n/12.045 版
+....\TU/FandolSong(0)/m/n/12.045 有
+....\glue 0.0 plus 0.61353
+....\TU/FandolSong(0)/m/n/12.045 序
+....\glue 0.0 plus 0.61353
+....\TU/FandolSong(0)/m/n/12.045 号
+....\glue 0.0 plus 0.61353
+....\TU/FandolSong(0)/m/n/12.045 的
+....\glue 0.0 plus 0.61353
+....\TU/FandolSong(0)/m/n/12.045 数
+....\glue 0.0 plus 0.61353
+....\TU/FandolSong(0)/m/n/12.045 字
+....\glue 0.0 plus 0.61353
+....\TU/FandolSong(0)/m/n/12.045 表
+....\glue 0.0 plus 0.61353
+....\TU/FandolSong(0)/m/n/12.045 达
+....\glue 0.0 plus 0.61353
+....\TU/FandolSong(0)/m/n/12.045 式
+....\penalty 10000
+....\TU/FandolSong(0)/m/n/12.045 。
+....\rule(0.0+0.0)x-7.75697
+....\kern 0.00047
+....\kern -0.00047
+....\kern -0.18753
+....\kern 0.18753
+....\penalty 10000
+....\glue(\parfillskip) 0.0 plus 1.0fil
+....\glue(\rightskip) 0.0
+...\penalty 10000
+...\glue(\abovedisplayskip) 6.02249 plus 3.01125 minus 3.01125
+...\glue(\baselineskip) 8.22273
+...\hbox(9.636+3.01152)x252.87306, shifted 164.24446
+....\hbox(5.5407+3.01152)x88.62862, display
+.....\hbox(0.0+0.0)x0.0
+.....\TU/XITSMath-Regular(1)/m/n/12.045 glyph#2523
+.....\hbox(6.10681+0.0)x5.01688, shifted 3.01152
+......\TU/XITSMath-Regular(1)/m/n/9.03375 glyph#50
+.....\glue(\thickmuskip) 3.3461 plus 3.3461
+.....\TU/XITSMath-Regular(1)/m/n/12.045 glyph#62
+.....\glue(\thickmuskip) 3.3461 plus 3.3461
+.....\TU/XITSMath-Regular(1)/m/n/12.045 glyph#2521
+.....\hbox(6.10681+0.0)x9.53375, shifted 3.01152
+......\TU/XITSMath-Regular(1)/m/n/9.03375 glyph#50
+......\TU/XITSMath-Regular(1)/m/n/9.03375 glyph#50
+.....\glue(\medmuskip) 2.67688 plus 1.33844 minus 2.67688
+.....\TU/XITSMath-Regular(1)/m/n/12.045 glyph#1155
+.....\glue(\medmuskip) 2.67688 plus 1.33844 minus 2.67688
+.....\TU/XITSMath-Regular(1)/m/n/12.045 glyph#2521
+.....\hbox(6.10681+0.0)x9.53375, shifted 3.01152
+......\TU/XITSMath-Regular(1)/m/n/9.03375 glyph#50
+......\TU/XITSMath-Regular(1)/m/n/9.03375 glyph#51
+.....\TU/XITSMath-Regular(1)/m/n/12.045 glyph#2521
+.....\hbox(6.10681+0.0)x9.53375, shifted 3.01152
+......\TU/XITSMath-Regular(1)/m/n/9.03375 glyph#51
+......\TU/XITSMath-Regular(1)/m/n/9.03375 glyph#50
+....\kern125.0982
+....\hbox(9.636+2.40898)x39.14624, display
+.....\hbox(9.636+2.40898)x39.14624
+......\kern 0.0
+......\glue 7.63654 minus 6.0225
+......\rule(0.0+0.0)x-7.63654
+......\TU/FandolSong(0)/m/n/12.045 （
+......\kern 0.00009
+......\kern -0.00009
+......\kern -0.99622
+......\kern 0.99622
+......\penalty 10000
+......\glue 0.0
+......\TU/texgyretermes(0)/m/n/12.045 2.1
+......\kern -0.0002
+......\kern 0.0002
+......\penalty 10000
+......\TU/FandolSong(0)/m/n/12.045 ）
+......\rule(0.0+0.0)x-7.63654
+......\kern 0.00047
+......\kern -0.00047
+......\kern -0.99623
+......\kern 0.99623
+......\glue 7.63654 minus 6.0225
+.....\write2{\newlabel{eq:example}{{2.1}{\thepage }{}{equation.2.1}{}}}
+...\penalty 0
+...\glue(\belowdisplayskip) 6.02249 plus 3.01125 minus 3.01125
+...\glue(\baselineskip) 7.69247
+...\hbox(9.371+2.32468)x417.11752, glue set 147.83954fil
+....\TU/FandolSong(0)/m/n/12.045 表
+....\glue 0.0 plus 0.61353
+....\TU/FandolSong(0)/m/n/12.045 达
+....\glue 0.0 plus 0.61353
+....\TU/FandolSong(0)/m/n/12.045 式
+....\glue 0.0 plus 0.61353
+....\TU/FandolSong(0)/m/n/12.045 的
+....\glue 0.0 plus 0.61353
+....\TU/FandolSong(0)/m/n/12.045 行
+....\glue 0.0 plus 0.61353
+....\TU/FandolSong(0)/m/n/12.045 距
+....\glue 0.0 plus 0.61353
+....\TU/FandolSong(0)/m/n/12.045 根
+....\glue 0.0 plus 0.61353
+....\TU/FandolSong(0)/m/n/12.045 据
+....\glue 0.0 plus 0.61353
+....\TU/FandolSong(0)/m/n/12.045 需
+....\glue 0.0 plus 0.61353
+....\TU/FandolSong(0)/m/n/12.045 要
+....\glue 0.0 plus 0.61353
+....\TU/FandolSong(0)/m/n/12.045 采
+....\glue 0.0 plus 0.61353
+....\TU/FandolSong(0)/m/n/12.045 用
 ....\penalty 10000
 ....\TU/FandolSong(0)/m/n/12.045 ，
 ....\rule(0.0+0.0)x-8.33514
 ....\glue 8.33514 minus 6.0225
 ....\glue 0.0 plus 0.61353
-....\TU/FandolSong(0)/m/n/12.045 表
+....\TU/FandolSong(0)/m/n/12.045 段
 ....\glue 0.0 plus 0.61353
-....\TU/FandolSong(0)/m/n/12.045 格
-....\glue 0.0 plus 0.61353
-....\TU/FandolSong(0)/m/n/12.045 与
-....\glue 0.0 plus 0.61353
-....\TU/FandolSong(0)/m/n/12.045 文
-....\glue 0.0 plus 0.61353
-....\TU/FandolSong(0)/m/n/12.045 字
-....\glue 0.0 plus 0.61353
-....\TU/FandolSong(0)/m/n/12.045 论
-....\glue 0.0 plus 0.61353
-....\TU/FandolSong(0)/m/n/12.045 述
+....\TU/FandolSong(0)/m/n/12.045 前
+....\glue 3.01125 plus 1.50562 minus 1.00374
+....\TU/texgyretermes(0)/m/n/12.045 6
+....\glue 3.01125 plus 1.50562 minus 1.00374
+....\TU/FandolSong(0)/m/n/12.045 磅
+....\penalty 10000
+....\TU/FandolSong(0)/m/n/12.045 、
+....\rule(0.0+0.0)x-7.85333
+....\glue 7.85333 minus 6.02249
 ....\glue 0.0 plus 0.61353
 ....\TU/FandolSong(0)/m/n/12.045 段
 ....\glue 0.0 plus 0.61353
-....\TU/FandolSong(0)/m/n/12.045 落
-....\glue 0.0 plus 0.61353
-....\TU/FandolSong(0)/m/n/12.045 应
-....\glue 0.0 plus 0.61353
-....\TU/FandolSong(0)/m/n/12.045 穿
-....\glue 0.0 plus 0.61353
-....\TU/FandolSong(0)/m/n/12.045 插
-....\glue 0.0 plus 0.61353
-....\TU/FandolSong(0)/m/n/12.045 排
-....\glue 0.0 plus 0.61353
-....\TU/FandolSong(0)/m/n/12.045 版
+....\TU/FandolSong(0)/m/n/12.045 后
+....\glue 3.01125 plus 1.50562 minus 1.00374
+....\TU/texgyretermes(0)/m/n/12.045 6
+....\glue 3.01125 plus 1.50562 minus 1.00374
+....\TU/FandolSong(0)/m/n/12.045 磅
 ....\penalty 10000
 ....\TU/FandolSong(0)/m/n/12.045 。
 ....\rule(0.0+0.0)x-7.75697
@@ -4477,15 +4692,15 @@ Completed box being shipped out [6]
 ...\glue 0.0 plus 1.0fil
 ...\glue 0.0
 ...\glue 0.0 plus 0.0001fil
-..\glue(\baselineskip) 7.63202
-..\hbox(14.84546+3.5232)x417.11752
+..\glue(\baselineskip) 8.23427
+..\hbox(14.24321+3.5232)x417.11752
 ...\special{color push  Black}
-...\hbox(14.84546+3.5232)x417.11752
+...\hbox(14.24321+3.5232)x417.11752
 ....\glue 0.0 plus 1.0fil minus 1.0fil
-....\hbox(14.84546+3.5232)x417.11752
-.....\vbox(14.84546+3.5232)x417.11752
+....\hbox(14.24321+3.5232)x417.11752
+.....\vbox(14.24321+3.5232)x417.11752
 ......\rule(0.0+0.0)x417.11752
-......\glue 6.6248
+......\glue 6.02255
 ......\hbox(8.22066+3.5232)x417.11752
 .......\hbox(0.0+0.0)x0.0, glue set - 417.11752fil
 ........\vbox(0.0+0.0)x417.11752
@@ -4518,26 +4733,7 @@ Completed box being shipped out [6]
 ..........\glue(\parfillskip) 0.0
 ..........\glue(\rightskip) 0.0
 ...\special{color pop}
-LaTeX Font Info:    Font shape `TU/XITSMath-Regular(1)/m/n' will be
-(Font)              scaled to size 9.03375pt on input line ....
-LaTeX Font Info:    Font shape `TU/XITSMath-Regular(1)/m/n' will be
-(Font)              scaled to size 7.227pt on input line ....
-LaTeX Font Info:    Font shape `TU/XITSMath-Regular(2)/m/n' will be
-(Font)              scaled to size 12.0461pt on input line ....
-LaTeX Font Info:    Font shape `TU/XITSMath-Regular(2)/m/n' will be
-(Font)              scaled to size 9.03458pt on input line ....
-LaTeX Font Info:    Font shape `TU/XITSMath-Regular(2)/m/n' will be
-(Font)              scaled to size 7.22766pt on input line ....
-LaTeX Font Info:    Font shape `TU/XITSMath-Regular(3)/m/n' will be
-(Font)              scaled to size 12.0437pt on input line ....
-LaTeX Font Info:    Font shape `TU/XITSMath-Regular(3)/m/n' will be
-(Font)              scaled to size 9.03278pt on input line ....
-LaTeX Font Info:    Font shape `TU/XITSMath-Regular(3)/m/n' will be
-(Font)              scaled to size 7.22623pt on input line ....
-LaTeX Font Info:    Font shape `TU/STIXTwoMath-Regular(0)/m/n' will be
-(Font)              scaled to size 8.59444pt on input line ....
-LaTeX Font Info:    Font shape `TU/STIXTwoMath-Regular(0)/m/n' will be
-(Font)              scaled to size 6.87555pt on input line ....
+第3章
 Completed box being shipped out [7]
 \vbox(722.98453+3.5232)x435.04271
 .\glue -29.59128
@@ -4613,208 +4809,70 @@ Completed box being shipped out [7]
 ....\special{color pop}
 ..\glue 15.6491
 ..\glue(\lineskip) 0.0
-..\vbox(700.50723+0.0)x417.11752, glue set 601.80333fil
+..\vbox(700.50723+0.0)x417.11752, glue set 630.89862fil
 ...\write-{}
-...\glue(\topskip) 1.15147
-...\hbox(10.84853+2.52943)x417.11752, glue set 329.65482fil
-....\hbox(9.96321+0.21077)x45.30524
-.....\TU/texgyreheros(0)/m/n/14.05249 2.1.3
-.....\kern -0.0002
-.....\kern 0.0002
-.....\glue 14.05249
-....\TU/FandolHei(0)/m/n/14.05249 表
-....\glue 0.0 plus 0.87584
-....\TU/FandolHei(0)/m/n/14.05249 达
-....\glue 0.0 plus 0.87584
-....\TU/FandolHei(0)/m/n/14.05249 式
+...\write2{\@writefile{toc}{\protect \addvspace {12bp}}}
+...\write2{\pp@pagectr{footnote}{3}{\theabspage }{\thepage }}
+...\write2{\@writefile{toc}{\protect \contentsline {chapter}{\protect \numberline {第3章}引用}{\thepage }{}\protected@file@percent }}
+...\glue(\topskip) 12.0
+...\rule(0.0+0.0)x*
+...\penalty 10000
+...\glue 7.02625
+...\glue 0.0
+...\glue(\parskip) 0.0
+...\glue(\parskip) 0.0
+...\glue(\baselineskip) 16.88107
+...\hbox(12.55891+2.8426)x417.11752, glue set 159.47942fil
+....\glue(\leftskip) 0.0 plus 1.0fil
+....\TU/FandolHei(0)/m/n/16.06 第
+....\glue 4.46468 plus 2.23233 minus 1.48822
+....\TU/texgyreheros(0)/m/n/16.06 3
+....\glue 4.46468 plus 2.23233 minus 1.48822
+....\TU/FandolHei(0)/m/n/16.06 章
+....\kern -0.00017
+....\kern 0.00017
+....\glue 16.06
+....\TU/FandolHei(0)/m/n/16.06 引
+....\glue 0.0 plus 1.37729
+....\TU/FandolHei(0)/m/n/16.06 用
 ....\kern -0.00017
 ....\kern 0.00017
 ....\penalty 10000
-....\glue(\parfillskip) 0.0 plus 1.0fil
-....\glue(\rightskip) 0.0
-...\write2{\@writefile{toc}{\protect \contentsline {subsection}{\protect \numberline {2.1.3}表达式}{\thepage }{}\protected@file@percent }}
+....\glue(\parfillskip) 0.0
+....\glue(\rightskip) 0.0 plus 1.0fil
 ...\penalty 10000
-...\glue 6.02249
+...\kern 1.0
 ...\glue(\parskip) 0.0
 ...\glue(\parskip) 0.0
-...\glue(\baselineskip) 10.12183
-...\hbox(9.43123+2.21626)x417.11752, glue set 135.79454fil
+...\glue(\baselineskip) 6.30714
+...\hbox(10.92525+0.0)x417.11752, glue set 380.99417fil
 ....\hbox(0.0+0.0)x24.09
-....\TU/FandolSong(0)/m/n/12.045 表
-....\glue 0.0 plus 0.61353
-....\TU/FandolSong(0)/m/n/12.045 达
-....\glue 0.0 plus 0.61353
-....\TU/FandolSong(0)/m/n/12.045 式
-....\glue 0.0 plus 0.61353
-....\TU/FandolSong(0)/m/n/12.045 主
-....\glue 0.0 plus 0.61353
-....\TU/FandolSong(0)/m/n/12.045 要
-....\glue 0.0 plus 0.61353
-....\TU/FandolSong(0)/m/n/12.045 是
-....\glue 0.0 plus 0.61353
-....\TU/FandolSong(0)/m/n/12.045 指
-....\glue 0.0 plus 0.61353
-....\TU/FandolSong(0)/m/n/12.045 分
-....\glue 0.0 plus 0.61353
-....\TU/FandolSong(0)/m/n/12.045 章
-....\glue 0.0 plus 0.61353
-....\TU/FandolSong(0)/m/n/12.045 连
-....\glue 0.0 plus 0.61353
-....\TU/FandolSong(0)/m/n/12.045 续
-....\glue 0.0 plus 0.61353
-....\TU/FandolSong(0)/m/n/12.045 编
-....\glue 0.0 plus 0.61353
-....\TU/FandolSong(0)/m/n/12.045 有
-....\glue 0.0 plus 0.61353
-....\TU/FandolSong(0)/m/n/12.045 序
-....\glue 0.0 plus 0.61353
-....\TU/FandolSong(0)/m/n/12.045 号
-....\glue 0.0 plus 0.61353
-....\TU/FandolSong(0)/m/n/12.045 的
-....\glue 0.0 plus 0.61353
-....\TU/FandolSong(0)/m/n/12.045 数
-....\glue 0.0 plus 0.61353
-....\TU/FandolSong(0)/m/n/12.045 字
-....\glue 0.0 plus 0.61353
-....\TU/FandolSong(0)/m/n/12.045 表
-....\glue 0.0 plus 0.61353
-....\TU/FandolSong(0)/m/n/12.045 达
-....\glue 0.0 plus 0.61353
-....\TU/FandolSong(0)/m/n/12.045 式
-....\penalty 10000
-....\TU/FandolSong(0)/m/n/12.045 。
-....\rule(0.0+0.0)x-7.75697
-....\kern 0.00047
-....\kern -0.00047
-....\kern -0.18753
-....\kern 0.18753
-....\penalty 10000
-....\glue(\parfillskip) 0.0 plus 1.0fil
-....\glue(\rightskip) 0.0
-...\penalty 10000
-...\glue(\abovedisplayskip) 6.02249 plus 3.01125 minus 3.01125
-...\glue(\baselineskip) 10.23022
-...\hbox(9.636+3.01152)x252.87306, shifted 164.24446
-....\hbox(5.5407+3.01152)x88.62862, display
-.....\hbox(0.0+0.0)x0.0
-.....\TU/XITSMath-Regular(1)/m/n/12.045 glyph#2523
-.....\hbox(6.10681+0.0)x5.01688, shifted 3.01152
-......\TU/XITSMath-Regular(1)/m/n/9.03375 glyph#50
-.....\glue(\thickmuskip) 3.3461 plus 3.3461
-.....\TU/XITSMath-Regular(1)/m/n/12.045 glyph#62
-.....\glue(\thickmuskip) 3.3461 plus 3.3461
-.....\TU/XITSMath-Regular(1)/m/n/12.045 glyph#2521
-.....\hbox(6.10681+0.0)x9.53375, shifted 3.01152
-......\TU/XITSMath-Regular(1)/m/n/9.03375 glyph#50
-......\TU/XITSMath-Regular(1)/m/n/9.03375 glyph#50
-.....\glue(\medmuskip) 2.67688 plus 1.33844 minus 2.67688
-.....\TU/XITSMath-Regular(1)/m/n/12.045 glyph#1155
-.....\glue(\medmuskip) 2.67688 plus 1.33844 minus 2.67688
-.....\TU/XITSMath-Regular(1)/m/n/12.045 glyph#2521
-.....\hbox(6.10681+0.0)x9.53375, shifted 3.01152
-......\TU/XITSMath-Regular(1)/m/n/9.03375 glyph#50
-......\TU/XITSMath-Regular(1)/m/n/9.03375 glyph#51
-.....\TU/XITSMath-Regular(1)/m/n/12.045 glyph#2521
-.....\hbox(6.10681+0.0)x9.53375, shifted 3.01152
-......\TU/XITSMath-Regular(1)/m/n/9.03375 glyph#51
-......\TU/XITSMath-Regular(1)/m/n/9.03375 glyph#50
-....\kern125.0982
-....\hbox(9.636+2.40898)x39.14624, display
-.....\hbox(9.636+2.40898)x39.14624
-......\kern 0.0
-......\glue 7.63654 minus 6.0225
-......\rule(0.0+0.0)x-7.63654
-......\TU/FandolSong(0)/m/n/12.045 （
-......\kern 0.00009
-......\kern -0.00009
-......\kern -0.99622
-......\kern 0.99622
-......\penalty 10000
-......\glue 0.0
-......\TU/texgyretermes(0)/m/n/12.045 2.1
+....\mathon
+....\hbox(6.10681+1.40926)x11.03336, shifted -4.81844
+.....\TU/texgyretermes(0)/m/n/9.03375 [
+.....\hbox(6.10681+0.0)x4.51688
+......\TU/texgyretermes(0)/m/n/9.03375 1
 ......\kern -0.0002
 ......\kern 0.0002
-......\penalty 10000
-......\TU/FandolSong(0)/m/n/12.045 ）
-......\rule(0.0+0.0)x-7.63654
-......\kern 0.00047
-......\kern -0.00047
-......\kern -0.99623
-......\kern 0.99623
-......\glue 7.63654 minus 6.0225
-.....\write2{\newlabel{eq:example}{{2.1}{\thepage }{}{equation.2.1}{}}}
-...\penalty 0
-...\glue(\belowdisplayskip) 6.02249 plus 3.01125 minus 3.01125
-...\glue(\baselineskip) 9.69997
-...\hbox(9.371+2.32468)x417.11752, glue set 147.83954fil
-....\TU/FandolSong(0)/m/n/12.045 表
-....\glue 0.0 plus 0.61353
-....\TU/FandolSong(0)/m/n/12.045 达
-....\glue 0.0 plus 0.61353
-....\TU/FandolSong(0)/m/n/12.045 式
-....\glue 0.0 plus 0.61353
-....\TU/FandolSong(0)/m/n/12.045 的
-....\glue 0.0 plus 0.61353
-....\TU/FandolSong(0)/m/n/12.045 行
-....\glue 0.0 plus 0.61353
-....\TU/FandolSong(0)/m/n/12.045 距
-....\glue 0.0 plus 0.61353
-....\TU/FandolSong(0)/m/n/12.045 根
-....\glue 0.0 plus 0.61353
-....\TU/FandolSong(0)/m/n/12.045 据
-....\glue 0.0 plus 0.61353
-....\TU/FandolSong(0)/m/n/12.045 需
-....\glue 0.0 plus 0.61353
-....\TU/FandolSong(0)/m/n/12.045 要
-....\glue 0.0 plus 0.61353
-....\TU/FandolSong(0)/m/n/12.045 采
-....\glue 0.0 plus 0.61353
-....\TU/FandolSong(0)/m/n/12.045 用
-....\penalty 10000
-....\TU/FandolSong(0)/m/n/12.045 ，
-....\rule(0.0+0.0)x-8.33514
-....\glue 8.33514 minus 6.0225
-....\glue 0.0 plus 0.61353
-....\TU/FandolSong(0)/m/n/12.045 段
-....\glue 0.0 plus 0.61353
-....\TU/FandolSong(0)/m/n/12.045 前
-....\glue 3.01125 plus 1.50562 minus 1.00374
-....\TU/texgyretermes(0)/m/n/12.045 6
-....\glue 3.01125 plus 1.50562 minus 1.00374
-....\TU/FandolSong(0)/m/n/12.045 磅
-....\penalty 10000
-....\TU/FandolSong(0)/m/n/12.045 、
-....\rule(0.0+0.0)x-7.85333
-....\glue 7.85333 minus 6.02249
-....\glue 0.0 plus 0.61353
-....\TU/FandolSong(0)/m/n/12.045 段
-....\glue 0.0 plus 0.61353
-....\TU/FandolSong(0)/m/n/12.045 后
-....\glue 3.01125 plus 1.50562 minus 1.00374
-....\TU/texgyretermes(0)/m/n/12.045 6
-....\glue 3.01125 plus 1.50562 minus 1.00374
-....\TU/FandolSong(0)/m/n/12.045 磅
-....\penalty 10000
-....\TU/FandolSong(0)/m/n/12.045 。
-....\rule(0.0+0.0)x-7.75697
-....\kern 0.00047
-....\kern -0.00047
-....\kern -0.18753
-....\kern 0.18753
+.....\TU/texgyretermes(0)/m/n/9.03375 ]
+.....\kern -0.0002
+.....\kern 0.0002
+....\mathoff
+....\kern 1.0
 ....\penalty 10000
 ....\glue(\parfillskip) 0.0 plus 1.0fil
 ....\glue(\rightskip) 0.0
 ...\glue 0.0 plus 1.0fil
 ...\glue 0.0
 ...\glue 0.0 plus 0.0001fil
-..\glue(\baselineskip) 7.63202
-..\hbox(14.84546+3.5232)x417.11752
+..\glue(\baselineskip) 8.23427
+..\hbox(14.24321+3.5232)x417.11752
 ...\special{color push  Black}
-...\hbox(14.84546+3.5232)x417.11752
-....\hbox(14.84546+3.5232)x417.11752
-.....\vbox(14.84546+3.5232)x417.11752
+...\hbox(14.24321+3.5232)x417.11752
+....\hbox(14.24321+3.5232)x417.11752
+.....\vbox(14.24321+3.5232)x417.11752
 ......\rule(0.0+0.0)x417.11752
-......\glue 6.6248
+......\glue 6.02255
 ......\hbox(8.22066+3.5232)x417.11752
 .......\hbox(0.0+0.0)x0.0, glue set - 417.11752fil
 ........\vbox(0.0+0.0)x417.11752
@@ -4848,7 +4906,6 @@ Completed box being shipped out [7]
 ..........\glue(\rightskip) 0.0
 ....\glue 0.0 plus 1.0fil minus 1.0fil
 ...\special{color pop}
-第3章
 Completed box being shipped out [8]
 \vbox(722.98453+3.5232)x435.04271
 .\glue -29.59128
@@ -4924,11 +4981,10 @@ Completed box being shipped out [8]
 ....\special{color pop}
 ..\glue 15.6491
 ..\glue(\lineskip) 0.0
-..\vbox(700.50723+0.0)x417.11752, glue set 628.89134fil
+..\vbox(700.50723+0.0)x417.11752, glue set 586.44757fil
 ...\write-{}
 ...\write2{\@writefile{toc}{\protect \addvspace {12bp}}}
-...\write2{\pp@pagectr{footnote}{3}{\theabspage }{\thepage }}
-...\write2{\@writefile{toc}{\protect \contentsline {chapter}{\protect \numberline {第3章}引用}{\thepage }{}\protected@file@percent }}
+...\write2{\@writefile{toc}{\protect \contentsline {chapter}{参考文献}{\thepage }{}\protected@file@percent }}
 ...\glue(\topskip) 12.0
 ...\rule(0.0+0.0)x*
 ...\penalty 10000
@@ -4936,59 +4992,123 @@ Completed box being shipped out [8]
 ...\glue 0.0
 ...\glue(\parskip) 0.0
 ...\glue(\parskip) 0.0
-...\glue(\baselineskip) 16.88107
-...\hbox(12.55891+2.8426)x417.11752, glue set 159.47942fil
+...\glue(\baselineskip) 18.94077
+...\hbox(14.18298+3.39667)x417.11752, glue set 158.87318fil
 ....\glue(\leftskip) 0.0 plus 1.0fil
-....\TU/FandolHei(0)/m/n/16.06 第
-....\glue 4.46468 plus 2.23233 minus 1.48822
-....\TU/texgyreheros(0)/m/n/16.06 3
-....\glue 4.46468 plus 2.23233 minus 1.48822
-....\TU/FandolHei(0)/m/n/16.06 章
-....\kern -0.00017
-....\kern 0.00017
-....\glue 16.06
-....\TU/FandolHei(0)/m/n/16.06 引
-....\glue 0.0 plus 1.37729
-....\TU/FandolHei(0)/m/n/16.06 用
+....\TU/FandolHei(0)/m/n/18.06749 参
+....\glue 9.03374 plus 1.40234 minus 0.4979
+....\TU/FandolHei(0)/m/n/18.06749 考
+....\glue 9.03374 plus 1.40234 minus 0.4979
+....\TU/FandolHei(0)/m/n/18.06749 文
+....\glue 9.03374 plus 1.40234 minus 0.4979
+....\TU/FandolHei(0)/m/n/18.06749 献
 ....\kern -0.00017
 ....\kern 0.00017
 ....\penalty 10000
 ....\glue(\parfillskip) 0.0
 ....\glue(\rightskip) 0.0 plus 1.0fil
 ...\penalty 10000
-...\kern 1.0
+...\glue 19.07124
 ...\glue(\parskip) 0.0
 ...\glue(\parskip) 0.0
-...\glue(\baselineskip) 8.31464
-...\hbox(10.92525+0.0)x417.11752, glue set 380.99417fil
-....\hbox(0.0+0.0)x24.09
-....\mathon
-....\hbox(6.10681+1.40926)x11.03336, shifted -4.81844
-.....\TU/texgyretermes(0)/m/n/9.03375 [
-.....\hbox(6.10681+0.0)x4.51688
-......\TU/texgyretermes(0)/m/n/9.03375 1
+...\glue(\baselineskip) 8.4516
+...\hbox(8.22673+2.71011)x387.00504, glue set - 0.07979, shifted 30.11249
+....\hbox(8.14243+1.879)x0.0
+.....\glue 0.0
+.....\glue -30.11249
+.....\glue 0.0
+.....\hbox(8.14243+1.879)x30.11249, glue set 16.06802fill
+......\special{color push  Black}
+......\glue 0.0 plus 1.0fil
+......\glue 0.0 plus 1.0fil
+......\TU/texgyretermes(0)/m/n/12.045 [1]
 ......\kern -0.0002
 ......\kern 0.0002
-.....\TU/texgyretermes(0)/m/n/9.03375 ]
+......\glue 0.0 plus 1.0fill
+......\special{color pop}
+.....\glue 0.0
+....\penalty 0
+....\TU/texgyretermes(0)/m/n/12.045 KNUTH
+....\kern -0.0002
+....\kern 0.0002
+....\penalty 10000
+....\glue 3.01125 plus 1.50562 minus 1.00374
+....\TU/texgyretermes(0)/m/n/12.045 D
+....\kern -0.0002
+....\kern 0.0002
+....\penalty 10000
+....\glue 3.01125 plus 1.50562 minus 1.00374
+....\TU/texgyretermes(0)/m/n/12.045 E.
+....\glue 3.01125 plus 1.50562 minus 1.00374
+....\glue 1.32495 plus 3.97487 minus 0.84323
+....\TU/texgyretermes(0)/m/n/12.045 Computers
+....\glue 3.01125 plus 1.50562 minus 1.00374
+....\TU/texgyretermes(0)/m/n/12.045 and
+....\glue 3.01125 plus 1.50562 minus 1.00374
+....\TU/texgyretermes(0)/m/n/12.045 typesetting:
+....\glue 4.01498 plus 3.01123 minus 0.50186
+....\TU/texgyretermes(0)/m/n/12.045 volume
+....\kern -0.0002
+....\kern 0.0002
+....\penalty 10000
+....\glue 3.01125 plus 1.50562 minus 1.00374
+....\TU/texgyretermes(0)/m/n/12.045 A
+....\kern -0.0002
+....\kern 0.0002
+....\glue 12.045
+....\TU/texgyretermes(0)/m/n/12.045 The
+....\glue 3.01125 plus 1.50562 minus 1.00374
+....\TU/texgyretermes(0)/m/n/12.045 T
+....\kern -0.0002
+....\kern 0.0002
+....\kern -2.00792
+....\hbox(7.97379+0.0)x7.3595, shifted 2.71011
+.....\TU/texgyretermes(0)/m/n/12.045 E
 .....\kern -0.0002
 .....\kern 0.0002
-....\mathoff
-....\kern 1.0
+....\kern -1.50562
+....\TU/texgyretermes(0)/m/n/12.045 X
+....\kern -0.0002
+....\kern 0.0002
+....\TU/texgyretermes(0)/m/n/12.045 book
+....\kern -0.0002
+....\kern 0.0002
+....\penalty 0
+....\TU/texgyretermes(0)/m/n/12.045 [M].
+....\glue 3.01125 plus 1.50562 minus 1.00374
+....\glue 1.32495 plus 3.97487 minus 0.84323
+....\TU/texgyretermes(0)/m/n/12.045 Read-
+....\glue(\rightskip) 0.0
+...\penalty 14100
+...\glue(\baselineskip) 9.1261
+...\hbox(8.23878+2.6258)x387.00504, glue set 199.12717fil, shifted 30.11249
+....\TU/texgyretermes(0)/m/n/12.045 ing,
+....\glue 3.01125 plus 1.88202 minus 0.80298
+....\TU/texgyretermes(0)/m/n/12.045 MA,
+....\glue 3.01125 plus 1.50562 minus 1.00374
+....\TU/texgyretermes(0)/m/n/12.045 USA:
+....\glue 3.01125 plus 1.50562 minus 1.00374
+....\TU/texgyretermes(0)/m/n/12.045 Addison-Wesley,
+....\glue 3.01125 plus 1.88202 minus 0.80298
+....\TU/texgyretermes(0)/m/n/12.045 1986.
 ....\penalty 10000
 ....\glue(\parfillskip) 0.0 plus 1.0fil
 ....\glue(\rightskip) 0.0
+...\penalty -51
+...\glue 0.0 plus 0.2
+...\glue 0.0 plus -0.2
 ...\glue 0.0 plus 1.0fil
 ...\glue 0.0
 ...\glue 0.0 plus 0.0001fil
-..\glue(\baselineskip) 7.63202
-..\hbox(14.84546+3.5232)x417.11752
+..\glue(\baselineskip) 8.23427
+..\hbox(14.24321+3.5232)x417.11752
 ...\special{color push  Black}
-...\hbox(14.84546+3.5232)x417.11752
+...\hbox(14.24321+3.5232)x417.11752
 ....\glue 0.0 plus 1.0fil minus 1.0fil
-....\hbox(14.84546+3.5232)x417.11752
-.....\vbox(14.84546+3.5232)x417.11752
+....\hbox(14.24321+3.5232)x417.11752
+.....\vbox(14.24321+3.5232)x417.11752
 ......\rule(0.0+0.0)x417.11752
-......\glue 6.6248
+......\glue 6.02255
 ......\hbox(8.22066+3.5232)x417.11752
 .......\hbox(0.0+0.0)x0.0, glue set - 417.11752fil
 ........\vbox(0.0+0.0)x417.11752
@@ -5021,6 +5141,7 @@ Completed box being shipped out [8]
 ..........\glue(\parfillskip) 0.0
 ..........\glue(\rightskip) 0.0
 ...\special{color pop}
+附录 A
 Completed box being shipped out [9]
 \vbox(722.98453+3.5232)x435.04271
 .\glue -29.59128
@@ -5096,10 +5217,10 @@ Completed box being shipped out [9]
 ....\special{color pop}
 ..\glue 15.6491
 ..\glue(\lineskip) 0.0
-..\vbox(700.50723+0.0)x417.11752, glue set 582.43301fil
+..\vbox(700.50723+0.0)x417.11752, glue set 610.62532fil
 ...\write-{}
-...\write2{\@writefile{toc}{\protect \addvspace {12bp}}}
-...\write2{\@writefile{toc}{\protect \contentsline {chapter}{参考文献}{\thepage }{}\protected@file@percent }}
+...\write2{\pp@pagectr{footnote}{4}{\theabspage }{\thepage }}
+...\write2{\@writefile{toc}{\protect \contentsline {chapter}{\protect \numberline {附录 A}附录章节}{\thepage }{}\protected@file@percent }}
 ...\glue(\topskip) 12.0
 ...\rule(0.0+0.0)x*
 ...\penalty 10000
@@ -5107,16 +5228,26 @@ Completed box being shipped out [9]
 ...\glue 0.0
 ...\glue(\parskip) 0.0
 ...\glue(\parskip) 0.0
-...\glue(\baselineskip) 18.94077
-...\hbox(14.18298+3.39667)x417.11752, glue set 158.87318fil
+...\glue(\baselineskip) 16.88107
+...\hbox(12.55891+2.7623)x417.11752, glue set 144.76042fil
 ....\glue(\leftskip) 0.0 plus 1.0fil
-....\TU/FandolHei(0)/m/n/18.06749 参
-....\glue 9.03374 plus 1.40234 minus 0.4979
-....\TU/FandolHei(0)/m/n/18.06749 考
-....\glue 9.03374 plus 1.40234 minus 0.4979
-....\TU/FandolHei(0)/m/n/18.06749 文
-....\glue 9.03374 plus 1.40234 minus 0.4979
-....\TU/FandolHei(0)/m/n/18.06749 献
+....\TU/FandolHei(0)/m/n/16.06 附
+....\glue 0.0 plus 1.37729
+....\TU/FandolHei(0)/m/n/16.06 录
+....\kern -0.00018
+....\kern 0.00018
+....\glue 4.46468 plus 2.23233 minus 1.48822
+....\TU/texgyreheros(0)/m/n/16.06 A
+....\kern -0.0002
+....\kern 0.0002
+....\glue 16.06
+....\TU/FandolHei(0)/m/n/16.06 附
+....\glue 0.0 plus 1.37729
+....\TU/FandolHei(0)/m/n/16.06 录
+....\glue 0.0 plus 1.37729
+....\TU/FandolHei(0)/m/n/16.06 章
+....\glue 0.0 plus 1.37729
+....\TU/FandolHei(0)/m/n/16.06 节
 ....\kern -0.00017
 ....\kern 0.00017
 ....\penalty 10000
@@ -5126,103 +5257,37 @@ Completed box being shipped out [9]
 ...\glue 19.07124
 ...\glue(\parskip) 0.0
 ...\glue(\parskip) 0.0
-...\glue(\baselineskip) 10.45909
-...\hbox(8.22673+2.71011)x387.00504, glue set - 0.07979, shifted 30.11249
-....\hbox(8.14243+1.879)x0.0
-.....\glue 0.0
-.....\glue -30.11249
-.....\glue 0.0
-.....\hbox(8.14243+1.879)x30.11249, glue set 16.06802fill
-......\special{color push  Black}
-......\glue 0.0 plus 1.0fil
-......\glue 0.0 plus 1.0fil
-......\TU/texgyretermes(0)/m/n/12.045 [1]
-......\kern -0.0002
-......\kern 0.0002
-......\glue 0.0 plus 1.0fill
-......\special{color pop}
-.....\glue 0.0
-....\penalty 0
-....\TU/texgyretermes(0)/m/n/12.045 KNUTH
-....\kern -0.0002
-....\kern 0.0002
+...\glue(\baselineskip) 8.0019
+...\hbox(9.31079+2.20422)x417.11752, glue set 340.55951fil
+....\hbox(0.0+0.0)x24.09
+....\TU/FandolSong(0)/m/n/12.045 附
+....\glue 0.0 plus 0.61353
+....\TU/FandolSong(0)/m/n/12.045 录
+....\glue 0.0 plus 0.61353
+....\TU/FandolSong(0)/m/n/12.045 内
+....\glue 0.0 plus 0.61353
+....\TU/FandolSong(0)/m/n/12.045 容
 ....\penalty 10000
-....\glue 3.01125 plus 1.50562 minus 1.00374
-....\TU/texgyretermes(0)/m/n/12.045 D
-....\kern -0.0002
-....\kern 0.0002
-....\penalty 10000
-....\glue 3.01125 plus 1.50562 minus 1.00374
-....\TU/texgyretermes(0)/m/n/12.045 E.
-....\glue 3.01125 plus 1.50562 minus 1.00374
-....\glue 1.32495 plus 3.97487 minus 0.84323
-....\TU/texgyretermes(0)/m/n/12.045 Computers
-....\glue 3.01125 plus 1.50562 minus 1.00374
-....\TU/texgyretermes(0)/m/n/12.045 and
-....\glue 3.01125 plus 1.50562 minus 1.00374
-....\TU/texgyretermes(0)/m/n/12.045 typesetting:
-....\glue 4.01498 plus 3.01123 minus 0.50186
-....\TU/texgyretermes(0)/m/n/12.045 volume
-....\kern -0.0002
-....\kern 0.0002
-....\penalty 10000
-....\glue 3.01125 plus 1.50562 minus 1.00374
-....\TU/texgyretermes(0)/m/n/12.045 A
-....\kern -0.0002
-....\kern 0.0002
-....\glue 12.045
-....\TU/texgyretermes(0)/m/n/12.045 The
-....\glue 3.01125 plus 1.50562 minus 1.00374
-....\TU/texgyretermes(0)/m/n/12.045 T
-....\kern -0.0002
-....\kern 0.0002
-....\kern -2.00792
-....\hbox(7.97379+0.0)x7.3595, shifted 2.71011
-.....\TU/texgyretermes(0)/m/n/12.045 E
-.....\kern -0.0002
-.....\kern 0.0002
-....\kern -1.50562
-....\TU/texgyretermes(0)/m/n/12.045 X
-....\kern -0.0002
-....\kern 0.0002
-....\TU/texgyretermes(0)/m/n/12.045 book
-....\kern -0.0002
-....\kern 0.0002
-....\penalty 0
-....\TU/texgyretermes(0)/m/n/12.045 [M].
-....\glue 3.01125 plus 1.50562 minus 1.00374
-....\glue 1.32495 plus 3.97487 minus 0.84323
-....\TU/texgyretermes(0)/m/n/12.045 Read-
-....\glue(\rightskip) 0.0
-...\penalty 14100
-...\glue(\baselineskip) 11.13359
-...\hbox(8.23878+2.6258)x387.00504, glue set 199.12717fil, shifted 30.11249
-....\TU/texgyretermes(0)/m/n/12.045 ing,
-....\glue 3.01125 plus 1.88202 minus 0.80298
-....\TU/texgyretermes(0)/m/n/12.045 MA,
-....\glue 3.01125 plus 1.50562 minus 1.00374
-....\TU/texgyretermes(0)/m/n/12.045 USA:
-....\glue 3.01125 plus 1.50562 minus 1.00374
-....\TU/texgyretermes(0)/m/n/12.045 Addison-Wesley,
-....\glue 3.01125 plus 1.88202 minus 0.80298
-....\TU/texgyretermes(0)/m/n/12.045 1986.
+....\TU/FandolSong(0)/m/n/12.045 。
+....\rule(0.0+0.0)x-7.75697
+....\kern 0.00047
+....\kern -0.00047
+....\kern -0.18753
+....\kern 0.18753
 ....\penalty 10000
 ....\glue(\parfillskip) 0.0 plus 1.0fil
 ....\glue(\rightskip) 0.0
-...\penalty -51
-...\glue 0.0 plus 0.2
-...\glue 0.0 plus -0.2
 ...\glue 0.0 plus 1.0fil
 ...\glue 0.0
 ...\glue 0.0 plus 0.0001fil
-..\glue(\baselineskip) 7.63202
-..\hbox(14.84546+3.5232)x417.11752
+..\glue(\baselineskip) 8.23427
+..\hbox(14.24321+3.5232)x417.11752
 ...\special{color push  Black}
-...\hbox(14.84546+3.5232)x417.11752
-....\hbox(14.84546+3.5232)x417.11752
-.....\vbox(14.84546+3.5232)x417.11752
+...\hbox(14.24321+3.5232)x417.11752
+....\hbox(14.24321+3.5232)x417.11752
+.....\vbox(14.24321+3.5232)x417.11752
 ......\rule(0.0+0.0)x417.11752
-......\glue 6.6248
+......\glue 6.02255
 ......\hbox(8.22066+3.5232)x417.11752
 .......\hbox(0.0+0.0)x0.0, glue set - 417.11752fil
 ........\vbox(0.0+0.0)x417.11752
@@ -5256,7 +5321,7 @@ Completed box being shipped out [9]
 ..........\glue(\rightskip) 0.0
 ....\glue 0.0 plus 1.0fil minus 1.0fil
 ...\special{color pop}
-附录 A
+)
 Completed box being shipped out [10]
 \vbox(722.98453+3.5232)x435.04271
 .\glue -29.59128
@@ -5332,10 +5397,10 @@ Completed box being shipped out [10]
 ....\special{color pop}
 ..\glue 15.6491
 ..\glue(\lineskip) 0.0
-..\vbox(700.50723+0.0)x417.11752, glue set 608.61804fil
+..\vbox(700.50723+0.0)x417.11752, glue set 566.9528fil
 ...\write-{}
-...\write2{\pp@pagectr{footnote}{4}{\theabspage }{\thepage }}
-...\write2{\@writefile{toc}{\protect \contentsline {chapter}{\protect \numberline {附录 A}附录章节}{\thepage }{}\protected@file@percent }}
+...\write-{}
+...\write2{\@writefile{toc}{\protect \contentsline {chapter}{致谢}{\thepage }{}\protected@file@percent }}
 ...\glue(\topskip) 12.0
 ...\rule(0.0+0.0)x*
 ...\penalty 10000
@@ -5343,26 +5408,12 @@ Completed box being shipped out [10]
 ...\glue 0.0
 ...\glue(\parskip) 0.0
 ...\glue(\parskip) 0.0
-...\glue(\baselineskip) 16.88107
-...\hbox(12.55891+2.7623)x417.11752, glue set 144.76042fil
+...\glue(\baselineskip) 19.13951
+...\hbox(13.98424+3.30634)x417.11752, glue set 181.45753fil
 ....\glue(\leftskip) 0.0 plus 1.0fil
-....\TU/FandolHei(0)/m/n/16.06 附
-....\glue 0.0 plus 1.37729
-....\TU/FandolHei(0)/m/n/16.06 录
-....\kern -0.00018
-....\kern 0.00018
-....\glue 4.46468 plus 2.23233 minus 1.48822
-....\TU/texgyreheros(0)/m/n/16.06 A
-....\kern -0.0002
-....\kern 0.0002
-....\glue 16.06
-....\TU/FandolHei(0)/m/n/16.06 附
-....\glue 0.0 plus 1.37729
-....\TU/FandolHei(0)/m/n/16.06 录
-....\glue 0.0 plus 1.37729
-....\TU/FandolHei(0)/m/n/16.06 章
-....\glue 0.0 plus 1.37729
-....\TU/FandolHei(0)/m/n/16.06 节
+....\TU/FandolHei(0)/m/n/18.06749 致
+....\glue 18.06749 plus 0.1423 minus 2.88081
+....\TU/FandolHei(0)/m/n/18.06749 谢
 ....\kern -0.00017
 ....\kern 0.00017
 ....\penalty 10000
@@ -5372,12 +5423,12 @@ Completed box being shipped out [10]
 ...\glue 19.07124
 ...\glue(\parskip) 0.0
 ...\glue(\parskip) 0.0
-...\glue(\baselineskip) 10.0094
-...\hbox(9.31079+2.20422)x417.11752, glue set 340.55951fil
+...\glue(\baselineskip) 7.44583
+...\hbox(9.32283+2.20422)x417.11752, glue set 340.55951fil
 ....\hbox(0.0+0.0)x24.09
-....\TU/FandolSong(0)/m/n/12.045 附
+....\TU/FandolSong(0)/m/n/12.045 致
 ....\glue 0.0 plus 0.61353
-....\TU/FandolSong(0)/m/n/12.045 录
+....\TU/FandolSong(0)/m/n/12.045 谢
 ....\glue 0.0 plus 0.61353
 ....\TU/FandolSong(0)/m/n/12.045 内
 ....\glue 0.0 plus 0.61353
@@ -5392,18 +5443,38 @@ Completed box being shipped out [10]
 ....\penalty 10000
 ....\glue(\parfillskip) 0.0 plus 1.0fil
 ....\glue(\rightskip) 0.0
+...\glue(\baselineskip) 17.87077
+...\hbox(0.0+0.0)x0.0
+...\glue(\parskip) 0.0
+...\glue(\parskip) 0.0
+...\glue(\baselineskip) 10.77626
+...\hbox(9.29874+2.04764)x417.11752, glue set 353.88129fil
+....\glue(\leftskip) 0.0 plus 1.0fil
+....\hbox(0.0+0.0)x0.0
+....\TU/texgyretermes(0)/m/n/12.045 2016
+....\glue 3.01125 plus 1.50562 minus 1.00374
+....\TU/FandolSong(0)/m/n/12.045 年
+....\glue 3.01125 plus 1.50562 minus 1.00374
+....\TU/texgyretermes(0)/m/n/12.045 5
+....\glue 3.01125 plus 1.50562 minus 1.00374
+....\TU/FandolSong(0)/m/n/12.045 月
+....\kern -0.00017
+....\kern 0.00017
+....\penalty 10000
+....\glue(\parfillskip) 0.0
+....\glue(\rightskip) 0.0
 ...\glue 0.0 plus 1.0fil
 ...\glue 0.0
 ...\glue 0.0 plus 0.0001fil
-..\glue(\baselineskip) 7.63202
-..\hbox(14.84546+3.5232)x417.11752
+..\glue(\baselineskip) 8.23427
+..\hbox(14.24321+3.5232)x417.11752
 ...\special{color push  Black}
-...\hbox(14.84546+3.5232)x417.11752
+...\hbox(14.24321+3.5232)x417.11752
 ....\glue 0.0 plus 1.0fil minus 1.0fil
-....\hbox(14.84546+3.5232)x417.11752
-.....\vbox(14.84546+3.5232)x417.11752
+....\hbox(14.24321+3.5232)x417.11752
+.....\vbox(14.24321+3.5232)x417.11752
 ......\rule(0.0+0.0)x417.11752
-......\glue 6.6248
+......\glue 6.02255
 ......\hbox(8.22066+3.5232)x417.11752
 .......\hbox(0.0+0.0)x0.0, glue set - 417.11752fil
 ........\vbox(0.0+0.0)x417.11752
@@ -5435,190 +5506,4 @@ Completed box being shipped out [10]
 ..........\penalty 10000
 ..........\glue(\parfillskip) 0.0
 ..........\glue(\rightskip) 0.0
-...\special{color pop}
-)
-Completed box being shipped out [11]
-\vbox(722.98453+3.5232)x435.04271
-.\glue -29.59128
-.\vbox(752.5758+3.5232)x417.11752, shifted 17.92519
-..\vbox(13.942+0.0)x417.11752, glue set 2.19815fil
-...\glue 0.0 plus 1.0fil
-...\hbox(11.74385+0.0)x417.11752
-....\special{color push  Black}
-....\hbox(11.74385+0.0)x417.11752
-.....\hbox(11.74385+0.0)x417.11752
-......\vbox(11.74385+0.0)x417.11752
-.......\hbox(8.22066+3.5232)x417.11752
-........\hbox(0.0+0.0)x0.0, glue set - 417.11752fil
-.........\vbox(0.0+0.0)x417.11752
-..........\hbox(0.0+0.0)x417.11752, glue set 208.55876fil
-...........\hbox(0.0+0.0)x0.0
-...........\penalty 10000
-...........\glue(\parfillskip) 0.0 plus 1.0fil
-...........\glue(\rightskip) 0.0 plus 1.0fil
-.........\glue 0.0 plus 1.0fil minus 1.0fil
-........\glue 0.0 plus 1.0fill
-........\vbox(8.22066+3.5232)x417.11752
-.........\hbox(8.22066+3.5232)x417.11752, glue set 145.3226fil
-..........\glue(\leftskip) 0.0 plus 1.0fil
-..........\hbox(0.0+0.0)x0.0
-..........\TU/FandolSong(0)/m/n/9.03374 中
-..........\glue 0.0 plus 0.24089
-..........\TU/FandolSong(0)/m/n/9.03374 国
-..........\glue 0.0 plus 0.24089
-..........\TU/FandolSong(0)/m/n/9.03374 科
-..........\glue 0.0 plus 0.24089
-..........\TU/FandolSong(0)/m/n/9.03374 学
-..........\glue 0.0 plus 0.24089
-..........\TU/FandolSong(0)/m/n/9.03374 技
-..........\glue 0.0 plus 0.24089
-..........\TU/FandolSong(0)/m/n/9.03374 术
-..........\glue 0.0 plus 0.24089
-..........\TU/FandolSong(0)/m/n/9.03374 大
-..........\glue 0.0 plus 0.24089
-..........\TU/FandolSong(0)/m/n/9.03374 学
-..........\glue 0.0 plus 0.24089
-..........\TU/FandolSong(0)/m/n/9.03374 本
-..........\glue 0.0 plus 0.24089
-..........\TU/FandolSong(0)/m/n/9.03374 科
-..........\glue 0.0 plus 0.24089
-..........\TU/FandolSong(0)/m/n/9.03374 毕
-..........\glue 0.0 plus 0.24089
-..........\TU/FandolSong(0)/m/n/9.03374 业
-..........\glue 0.0 plus 0.24089
-..........\TU/FandolSong(0)/m/n/9.03374 论
-..........\glue 0.0 plus 0.24089
-..........\TU/FandolSong(0)/m/n/9.03374 文
-..........\kern -0.00017
-..........\kern 0.00017
-..........\rule(8.22066+3.5232)x0.0
-..........\penalty 10000
-..........\glue(\parfillskip) 0.0
-..........\glue(\rightskip) 0.0 plus 1.0fil
-........\glue 0.0 plus 1.0fill
-........\hbox(0.0+0.0)x0.0, glue set - 417.11752fil
-.........\glue 0.0 plus 1.0fil minus 1.0fil
-.........\vbox(0.0+0.0)x417.11752
-..........\hbox(0.0+0.0)x417.11752, glue set 417.11752fil
-...........\glue(\leftskip) 0.0 plus 1.0fil
-...........\hbox(0.0+0.0)x0.0
-...........\penalty 10000
-...........\glue(\parfillskip) 0.0
-...........\glue(\rightskip) 0.0
-.......\glue 0.0
-.......\rule(0.7528+0.0)x417.11752
-.......\glue -0.7528
-.....\glue 0.0 plus 1.0fil minus 1.0fil
-....\special{color pop}
-..\glue 15.6491
-..\glue(\lineskip) 0.0
-..\vbox(700.50723+0.0)x417.11752, glue set 560.93097fil
-...\write-{}
-...\write-{}
-...\write2{\@writefile{toc}{\protect \contentsline {chapter}{致谢}{\thepage }{}\protected@file@percent }}
-...\glue(\topskip) 12.0
-...\rule(0.0+0.0)x*
-...\penalty 10000
-...\glue 7.02625
-...\glue 0.0
-...\glue(\parskip) 0.0
-...\glue(\parskip) 0.0
-...\glue(\baselineskip) 19.13951
-...\hbox(13.98424+3.30634)x417.11752, glue set 181.45753fil
-....\glue(\leftskip) 0.0 plus 1.0fil
-....\TU/FandolHei(0)/m/n/18.06749 致
-....\glue 18.06749 plus 0.1423 minus 2.88081
-....\TU/FandolHei(0)/m/n/18.06749 谢
-....\kern -0.00017
-....\kern 0.00017
-....\penalty 10000
-....\glue(\parfillskip) 0.0
-....\glue(\rightskip) 0.0 plus 1.0fil
-...\penalty 10000
-...\glue 19.07124
-...\glue(\parskip) 0.0
-...\glue(\parskip) 0.0
-...\glue(\baselineskip) 9.45332
-...\hbox(9.32283+2.20422)x417.11752, glue set 340.55951fil
-....\hbox(0.0+0.0)x24.09
-....\TU/FandolSong(0)/m/n/12.045 致
-....\glue 0.0 plus 0.61353
-....\TU/FandolSong(0)/m/n/12.045 谢
-....\glue 0.0 plus 0.61353
-....\TU/FandolSong(0)/m/n/12.045 内
-....\glue 0.0 plus 0.61353
-....\TU/FandolSong(0)/m/n/12.045 容
-....\penalty 10000
-....\TU/FandolSong(0)/m/n/12.045 。
-....\rule(0.0+0.0)x-7.75697
-....\kern 0.00047
-....\kern -0.00047
-....\kern -0.18753
-....\kern 0.18753
-....\penalty 10000
-....\glue(\parfillskip) 0.0 plus 1.0fil
-....\glue(\rightskip) 0.0
-...\glue(\baselineskip) 19.87827
-...\hbox(0.0+0.0)x0.0
-...\glue(\parskip) 0.0
-...\glue(\parskip) 0.0
-...\glue(\baselineskip) 12.78375
-...\hbox(9.29874+2.04764)x417.11752, glue set 353.88129fil
-....\glue(\leftskip) 0.0 plus 1.0fil
-....\hbox(0.0+0.0)x0.0
-....\TU/texgyretermes(0)/m/n/12.045 2016
-....\glue 3.01125 plus 1.50562 minus 1.00374
-....\TU/FandolSong(0)/m/n/12.045 年
-....\glue 3.01125 plus 1.50562 minus 1.00374
-....\TU/texgyretermes(0)/m/n/12.045 5
-....\glue 3.01125 plus 1.50562 minus 1.00374
-....\TU/FandolSong(0)/m/n/12.045 月
-....\kern -0.00017
-....\kern 0.00017
-....\penalty 10000
-....\glue(\parfillskip) 0.0
-....\glue(\rightskip) 0.0
-...\glue 0.0 plus 1.0fil
-...\glue 0.0
-...\glue 0.0 plus 0.0001fil
-..\glue(\baselineskip) 7.63202
-..\hbox(14.84546+3.5232)x417.11752
-...\special{color push  Black}
-...\hbox(14.84546+3.5232)x417.11752
-....\hbox(14.84546+3.5232)x417.11752
-.....\vbox(14.84546+3.5232)x417.11752
-......\rule(0.0+0.0)x417.11752
-......\glue 6.6248
-......\hbox(8.22066+3.5232)x417.11752
-.......\hbox(0.0+0.0)x0.0, glue set - 417.11752fil
-........\vbox(0.0+0.0)x417.11752
-.........\hbox(0.0+0.0)x417.11752, glue set 208.55876fil
-..........\hbox(0.0+0.0)x0.0
-..........\penalty 10000
-..........\glue(\parfillskip) 0.0 plus 1.0fil
-..........\glue(\rightskip) 0.0 plus 1.0fil
-........\glue 0.0 plus 1.0fil minus 1.0fil
-.......\glue 0.0 plus 1.0fill
-.......\vbox(8.22066+3.5232)x417.11752
-........\hbox(8.22066+3.5232)x417.11752, glue set 204.0419fil
-.........\glue(\leftskip) 0.0 plus 1.0fil
-.........\hbox(0.0+0.0)x0.0
-.........\TU/texgyretermes(0)/m/n/9.03374 11
-.........\kern -0.0002
-.........\kern 0.0002
-.........\rule(8.22066+3.5232)x0.0
-.........\penalty 10000
-.........\glue(\parfillskip) 0.0
-.........\glue(\rightskip) 0.0 plus 1.0fil
-.......\glue 0.0 plus 1.0fill
-.......\hbox(0.0+0.0)x0.0, glue set - 417.11752fil
-........\glue 0.0 plus 1.0fil minus 1.0fil
-........\vbox(0.0+0.0)x417.11752
-.........\hbox(0.0+0.0)x417.11752, glue set 417.11752fil
-..........\glue(\leftskip) 0.0 plus 1.0fil
-..........\hbox(0.0+0.0)x0.0
-..........\penalty 10000
-..........\glue(\parfillskip) 0.0
-..........\glue(\rightskip) 0.0
-....\glue 0.0 plus 1.0fil minus 1.0fil
 ...\special{color pop}

--- a/test/testfiles-crossref/main-bachelor-arabic.tlg
+++ b/test/testfiles-crossref/main-bachelor-arabic.tlg
@@ -777,7 +777,7 @@ Completed box being shipped out [1]
 ....\special{color pop}
 ..\glue 15.6491
 ..\glue(\lineskip) 0.0
-..\vbox(700.50723+0.0)x417.11752, glue set 346.19151fil
+..\vbox(700.50723+0.0)x417.11752, glue set 382.32265fil
 ...\write-{}
 ...\write-{}
 ...\write-{}
@@ -811,22 +811,22 @@ Completed box being shipped out [1]
 ....\glue(\leftskip) 48.18
 ....\hbox(0.0+0.0)x0.0
 ....\rule(14.05243+6.02255)x0.0
-....\hbox(9.35896+2.21626)x0.0, glue set - 48.18fil
+....\hbox(9.20238+2.15604)x0.0, glue set - 48.18fil
 .....\glue 0.0 plus 1.0fil minus 1.0fil
-.....\hbox(9.35896+2.21626)x48.18
+.....\hbox(9.20238+2.15604)x48.18
 ......\special{color push  Black}
-......\TU/FandolSong(0)/m/n/12.045 第
+......\TU/FandolSong(0)/b/n/12.045 第
 ......\glue 3.01125 plus 1.50562 minus 1.00374
-......\TU/texgyretermes(0)/m/n/12.045 1
+......\TU/texgyretermes(0)/b/n/12.045 1
 ......\glue 3.01125 plus 1.50562 minus 1.00374
-......\TU/FandolSong(0)/m/n/12.045 章
+......\TU/FandolSong(0)/b/n/12.045 章
 ......\kern -0.00017
 ......\kern 0.00017
 ......\glue 12.045
 ......\special{color pop}
-....\TU/FandolSong(0)/m/n/12.045 引
+....\TU/FandolSong(0)/b/n/12.045 引
 ....\glue 0.0 plus 0.61353
-....\TU/FandolSong(0)/m/n/12.045 言
+....\TU/FandolSong(0)/b/n/12.045 言
 ....\kern -0.00017
 ....\kern 0.00017
 ....\rule(14.05243+6.02255)x0.0
@@ -858,8 +858,8 @@ Completed box being shipped out [1]
 ...\glue(\parskip) 0.0
 ...\glue(\parskip) 0.0
 ...\glue(\baselineskip) 0.00002
-...\hbox(14.05243+6.02255)x417.11752, glue set 224.39757fill
-....\glue(\leftskip) 39.14624
+...\hbox(14.05243+6.02255)x417.11752, glue set 212.35257fill
+....\glue(\leftskip) 51.19124
 ....\hbox(0.0+0.0)x0.0
 ....\rule(14.05243+6.02255)x0.0
 ....\hbox(8.14243+0.13248)x0.0, glue set - 27.10124fil
@@ -925,8 +925,8 @@ Completed box being shipped out [1]
 ...\glue(\parskip) 0.0
 ...\glue(\parskip) 0.0
 ...\glue(\baselineskip) 0.00002
-...\hbox(14.05243+6.02255)x417.11752, glue set 275.5888fill
-....\glue(\leftskip) 60.22499
+...\hbox(14.05243+6.02255)x417.11752, glue set 251.49881fill
+....\glue(\leftskip) 84.31499
 ....\hbox(0.0+0.0)x0.0
 ....\rule(14.05243+6.02255)x0.0
 ....\hbox(8.14243+0.13248)x0.0, glue set - 36.135fil
@@ -974,11 +974,7 @@ Completed box being shipped out [1]
 ....\glue(\parfillskip) 0.0 plus 1.0fil
 ....\glue(\rightskip) 0.0
 ...\penalty 10000
-...\glue 12.045
-...\glue -18.045
 ...\penalty -300
-...\glue 6.0
-...\glue 12.045
 ...\glue 0.0 plus 0.1
 ...\penalty 10000
 ...\glue(\parskip) 0.0
@@ -988,26 +984,26 @@ Completed box being shipped out [1]
 ....\glue(\leftskip) 48.18
 ....\hbox(0.0+0.0)x0.0
 ....\rule(14.05243+6.02255)x0.0
-....\hbox(9.35896+2.21626)x0.0, glue set - 48.18fil
+....\hbox(9.20238+2.15604)x0.0, glue set - 48.18fil
 .....\glue 0.0 plus 1.0fil minus 1.0fil
-.....\hbox(9.35896+2.21626)x48.18
+.....\hbox(9.20238+2.15604)x48.18
 ......\special{color push  Black}
-......\TU/FandolSong(0)/m/n/12.045 第
+......\TU/FandolSong(0)/b/n/12.045 第
 ......\glue 3.01125 plus 1.50562 minus 1.00374
-......\TU/texgyretermes(0)/m/n/12.045 2
+......\TU/texgyretermes(0)/b/n/12.045 2
 ......\glue 3.01125 plus 1.50562 minus 1.00374
-......\TU/FandolSong(0)/m/n/12.045 章
+......\TU/FandolSong(0)/b/n/12.045 章
 ......\kern -0.00017
 ......\kern 0.00017
 ......\glue 12.045
 ......\special{color pop}
-....\TU/FandolSong(0)/m/n/12.045 内
+....\TU/FandolSong(0)/b/n/12.045 内
 ....\glue 0.0 plus 0.61353
-....\TU/FandolSong(0)/m/n/12.045 容
+....\TU/FandolSong(0)/b/n/12.045 容
 ....\glue 0.0 plus 0.61353
-....\TU/FandolSong(0)/m/n/12.045 要
+....\TU/FandolSong(0)/b/n/12.045 要
 ....\glue 0.0 plus 0.61353
-....\TU/FandolSong(0)/m/n/12.045 素
+....\TU/FandolSong(0)/b/n/12.045 素
 ....\kern -0.00017
 ....\kern 0.00017
 ....\rule(14.05243+6.02255)x0.0
@@ -1039,8 +1035,8 @@ Completed box being shipped out [1]
 ...\glue(\parskip) 0.0
 ...\glue(\parskip) 0.0
 ...\glue(\baselineskip) 0.00002
-...\hbox(14.05243+6.02255)x417.11752, glue set 260.53256fill
-....\glue(\leftskip) 39.14624
+...\hbox(14.05243+6.02255)x417.11752, glue set 248.48756fill
+....\glue(\leftskip) 51.19124
 ....\hbox(0.0+0.0)x0.0
 ....\rule(14.05243+6.02255)x0.0
 ....\hbox(8.14243+0.13248)x0.0, glue set - 27.10124fil
@@ -1102,8 +1098,8 @@ Completed box being shipped out [1]
 ...\glue(\parskip) 0.0
 ...\glue(\parskip) 0.0
 ...\glue(\baselineskip) 0.00002
-...\hbox(14.05243+6.02255)x417.11752, glue set 323.7688fill
-....\glue(\leftskip) 60.22499
+...\hbox(14.05243+6.02255)x417.11752, glue set 299.6788fill
+....\glue(\leftskip) 84.31499
 ....\hbox(0.0+0.0)x0.0
 ....\rule(14.05243+6.02255)x0.0
 ....\hbox(8.14243+0.13248)x0.0, glue set - 36.135fil
@@ -1149,8 +1145,8 @@ Completed box being shipped out [1]
 ...\glue(\parskip) 0.0
 ...\glue(\parskip) 0.0
 ...\glue(\baselineskip) 0.00002
-...\hbox(14.05243+6.02255)x417.11752, glue set 323.7688fill
-....\glue(\leftskip) 60.22499
+...\hbox(14.05243+6.02255)x417.11752, glue set 299.6788fill
+....\glue(\leftskip) 84.31499
 ....\hbox(0.0+0.0)x0.0
 ....\rule(14.05243+6.02255)x0.0
 ....\hbox(8.14243+0.13248)x0.0, glue set - 36.135fil
@@ -1196,8 +1192,8 @@ Completed box being shipped out [1]
 ...\glue(\parskip) 0.0
 ...\glue(\parskip) 0.0
 ...\glue(\baselineskip) 0.00002
-...\hbox(14.05243+6.02255)x417.11752, glue set 311.7238fill
-....\glue(\leftskip) 60.22499
+...\hbox(14.05243+6.02255)x417.11752, glue set 287.6338fill
+....\glue(\leftskip) 84.31499
 ....\hbox(0.0+0.0)x0.0
 ....\rule(14.05243+6.02255)x0.0
 ....\hbox(8.14243+0.16861)x0.0, glue set - 36.135fil
@@ -1239,11 +1235,7 @@ Completed box being shipped out [1]
 ....\glue(\parfillskip) 0.0 plus 1.0fil
 ....\glue(\rightskip) 0.0
 ...\penalty 10000
-...\glue 12.045
-...\glue -18.045
 ...\penalty -300
-...\glue 6.0
-...\glue 12.045
 ...\glue 0.0 plus 0.1
 ...\penalty 10000
 ...\glue(\parskip) 0.0
@@ -1253,22 +1245,22 @@ Completed box being shipped out [1]
 ....\glue(\leftskip) 48.18
 ....\hbox(0.0+0.0)x0.0
 ....\rule(14.05243+6.02255)x0.0
-....\hbox(9.35896+2.21626)x0.0, glue set - 48.18fil
+....\hbox(9.20238+2.15604)x0.0, glue set - 48.18fil
 .....\glue 0.0 plus 1.0fil minus 1.0fil
-.....\hbox(9.35896+2.21626)x48.18
+.....\hbox(9.20238+2.15604)x48.18
 ......\special{color push  Black}
-......\TU/FandolSong(0)/m/n/12.045 第
+......\TU/FandolSong(0)/b/n/12.045 第
 ......\glue 3.01125 plus 1.50562 minus 1.00374
-......\TU/texgyretermes(0)/m/n/12.045 3
+......\TU/texgyretermes(0)/b/n/12.045 3
 ......\glue 3.01125 plus 1.50562 minus 1.00374
-......\TU/FandolSong(0)/m/n/12.045 章
+......\TU/FandolSong(0)/b/n/12.045 章
 ......\kern -0.00017
 ......\kern 0.00017
 ......\glue 12.045
 ......\special{color pop}
-....\TU/FandolSong(0)/m/n/12.045 引
+....\TU/FandolSong(0)/b/n/12.045 引
 ....\glue 0.0 plus 0.61353
-....\TU/FandolSong(0)/m/n/12.045 用
+....\TU/FandolSong(0)/b/n/12.045 用
 ....\kern -0.00017
 ....\kern 0.00017
 ....\rule(14.05243+6.02255)x0.0
@@ -1294,11 +1286,7 @@ Completed box being shipped out [1]
 ....\glue(\parfillskip) 0.0 plus 1.0fil
 ....\glue(\rightskip) 0.0
 ...\penalty 10000
-...\glue 12.045
-...\glue -18.045
 ...\penalty 0
-...\glue 6.0
-...\glue 12.045
 ...\glue 0.0 plus 0.1
 ...\penalty 10000
 ...\glue(\parskip) 0.0
@@ -1307,13 +1295,13 @@ Completed box being shipped out [1]
 ...\hbox(14.05243+6.02255)x417.11752, glue set 359.9038fill
 ....\hbox(0.0+0.0)x0.0
 ....\rule(14.05243+6.02255)x0.0
-....\TU/FandolSong(0)/m/n/12.045 参
+....\TU/FandolSong(0)/b/n/12.045 参
 ....\glue 0.0 plus 0.61353
-....\TU/FandolSong(0)/m/n/12.045 考
+....\TU/FandolSong(0)/b/n/12.045 考
 ....\glue 0.0 plus 0.61353
-....\TU/FandolSong(0)/m/n/12.045 文
+....\TU/FandolSong(0)/b/n/12.045 文
 ....\glue 0.0 plus 0.61353
-....\TU/FandolSong(0)/m/n/12.045 献
+....\TU/FandolSong(0)/b/n/12.045 献
 ....\kern -0.00017
 ....\kern 0.00017
 ....\rule(14.05243+6.02255)x0.0
@@ -1349,26 +1337,26 @@ Completed box being shipped out [1]
 ....\glue(\leftskip) 47.84273
 ....\hbox(0.0+0.0)x0.0
 ....\rule(14.05243+6.02255)x0.0
-....\hbox(9.14215+1.99945)x0.0, glue set - 47.84273fil
+....\hbox(8.97353+1.75856)x0.0, glue set - 47.84273fil
 .....\glue 0.0 plus 1.0fil minus 1.0fil
-.....\hbox(9.14215+1.99945)x47.84273
+.....\hbox(8.97353+1.75856)x47.84273
 ......\special{color push  Black}
-......\TU/FandolSong(0)/m/n/12.045 附
+......\TU/FandolSong(0)/b/n/12.045 附
 ......\glue 0.0 plus 0.61353
-......\TU/FandolSong(0)/m/n/12.045 录
+......\TU/FandolSong(0)/b/n/12.045 录
 ......\glue 3.01125 plus 1.5041 minus 1.00473
-......\TU/texgyretermes(0)/m/n/12.045 A
+......\TU/texgyretermes(0)/b/n/12.045 A
 ......\kern -0.0002
 ......\kern 0.0002
 ......\glue 12.045
 ......\special{color pop}
-....\TU/FandolSong(0)/m/n/12.045 附
+....\TU/FandolSong(0)/b/n/12.045 附
 ....\glue 0.0 plus 0.61353
-....\TU/FandolSong(0)/m/n/12.045 录
+....\TU/FandolSong(0)/b/n/12.045 录
 ....\glue 0.0 plus 0.61353
-....\TU/FandolSong(0)/m/n/12.045 章
+....\TU/FandolSong(0)/b/n/12.045 章
 ....\glue 0.0 plus 0.61353
-....\TU/FandolSong(0)/m/n/12.045 节
+....\TU/FandolSong(0)/b/n/12.045 节
 ....\kern -0.00017
 ....\kern 0.00017
 ....\rule(14.05243+6.02255)x0.0
@@ -1403,9 +1391,9 @@ Completed box being shipped out [1]
 ...\hbox(14.05243+6.02255)x417.11752, glue set 377.9713fill
 ....\hbox(0.0+0.0)x0.0
 ....\rule(14.05243+6.02255)x0.0
-....\TU/FandolSong(0)/m/n/12.045 致
+....\TU/FandolSong(0)/b/n/12.045 致
 ....\glue 0.0 plus 0.61353
-....\TU/FandolSong(0)/m/n/12.045 谢
+....\TU/FandolSong(0)/b/n/12.045 谢
 ....\kern -0.00017
 ....\kern 0.00017
 ....\rule(14.05243+6.02255)x0.0
@@ -1993,7 +1981,6 @@ Completed box being shipped out [4]
 ..\vbox(700.50723+0.0)x417.11752, glue set 268.42937fil
 ...\write-{}
 ...\write-{}
-...\write2{\@writefile{toc}{\protect \addvspace {12bp}}}
 ...\write2{\pp@pagectr{footnote}{1}{\theabspage }{\thepage }}
 ...\write2{\@writefile{toc}{\protect \contentsline {chapter}{\protect \numberline {第1章}引言}{\thepage }{}\protected@file@percent }}
 ...\glue(\topskip) 12.0
@@ -3127,7 +3114,6 @@ Completed box being shipped out [5]
 ..\glue(\lineskip) 0.0
 ..\vbox(700.50723+0.0)x417.11752, glue set 6.00505fil
 ...\write-{}
-...\write2{\@writefile{toc}{\protect \addvspace {12bp}}}
 ...\write2{\pp@pagectr{footnote}{2}{\theabspage }{\thepage }}
 ...\write2{\@writefile{toc}{\protect \contentsline {chapter}{\protect \numberline {第2章}内容要素}{\thepage }{}\protected@file@percent }}
 ...\glue(\topskip) 12.0
@@ -4811,7 +4797,6 @@ Completed box being shipped out [7]
 ..\glue(\lineskip) 0.0
 ..\vbox(700.50723+0.0)x417.11752, glue set 630.89862fil
 ...\write-{}
-...\write2{\@writefile{toc}{\protect \addvspace {12bp}}}
 ...\write2{\pp@pagectr{footnote}{3}{\theabspage }{\thepage }}
 ...\write2{\@writefile{toc}{\protect \contentsline {chapter}{\protect \numberline {第3章}引用}{\thepage }{}\protected@file@percent }}
 ...\glue(\topskip) 12.0
@@ -4983,7 +4968,6 @@ Completed box being shipped out [8]
 ..\glue(\lineskip) 0.0
 ..\vbox(700.50723+0.0)x417.11752, glue set 586.44757fil
 ...\write-{}
-...\write2{\@writefile{toc}{\protect \addvspace {12bp}}}
 ...\write2{\@writefile{toc}{\protect \contentsline {chapter}{参考文献}{\thepage }{}\protected@file@percent }}
 ...\glue(\topskip) 12.0
 ...\rule(0.0+0.0)x*

--- a/test/testfiles-crossref/main-bachelor-arabic.tlg
+++ b/test/testfiles-crossref/main-bachelor-arabic.tlg
@@ -2386,8 +2386,7 @@ Completed box being shipped out [4]
 ...\glue(\parskip) 0.0
 ...\glue(\parskip) 0.0
 ...\glue(\baselineskip) 13.47435
-...\hbox(11.8041+2.66495)x417.11752, glue set 100.2291fil
-....\glue(\leftskip) 0.0 plus 1.0fil
+...\hbox(11.8041+2.66495)x417.11752, glue set 200.45818fil
 ....\hbox(10.67488+0.0)x35.98442
 .....\TU/texgyreheros(0)/m/n/15.05624 1.1
 .....\kern -0.0002
@@ -2419,8 +2418,8 @@ Completed box being shipped out [4]
 ....\kern -0.00017
 ....\kern 0.00017
 ....\penalty 10000
-....\glue(\parfillskip) 0.0
-....\glue(\rightskip) 0.0 plus 1.0fil
+....\glue(\parfillskip) 0.0 plus 1.0fil
+....\glue(\rightskip) 0.0
 ...\write2{\@writefile{toc}{\protect \contentsline {section}{\protect \numberline {1.1}学位论文中的常见问题分析}{\thepage }{}\protected@file@percent }}
 ...\penalty 10000
 ...\glue 6.02249
@@ -3161,8 +3160,7 @@ Completed box being shipped out [5]
 ...\glue(\parskip) 0.0
 ...\glue(\parskip) 0.0
 ...\glue(\baselineskip) 13.00159
-...\hbox(11.75893+2.71011)x417.11752, glue set 122.81346fil
-....\glue(\leftskip) 0.0 plus 1.0fil
+...\hbox(11.75893+2.71011)x417.11752, glue set 245.6269fil
 ....\hbox(10.67488+0.0)x35.98442
 .....\TU/texgyreheros(0)/m/n/15.05624 2.1
 .....\kern -0.0002
@@ -3190,8 +3188,8 @@ Completed box being shipped out [5]
 ....\kern -0.00017
 ....\kern 0.00017
 ....\penalty 10000
-....\glue(\parfillskip) 0.0
-....\glue(\rightskip) 0.0 plus 1.0fil
+....\glue(\parfillskip) 0.0 plus 1.0fil
+....\glue(\rightskip) 0.0
 ...\write2{\@writefile{toc}{\protect \contentsline {section}{\protect \numberline {2.1}有关图、表和表达式}{\thepage }{}\protected@file@percent }}
 ...\penalty 10000
 ...\penalty 10000

--- a/test/testfiles-crossref/main-bachelor-arabic.tlg
+++ b/test/testfiles-crossref/main-bachelor-arabic.tlg
@@ -97,10 +97,10 @@ Completed box being shipped out [1]
 ...\glue(\parskip) 0.0
 ...\glue(\parskip) 0.0
 ...\glue(\baselineskip) 19.21178
-...\hbox(13.91197+3.14372)x417.11752, glue set 181.45753fil
+...\hbox(13.91197+3.14372)x417.11752, glue set 190.49127fil
 ....\glue(\leftskip) 0.0 plus 1.0fil
 ....\TU/FandolHei(0)/m/n/18.06749 摘
-....\glue 18.06749 plus 0.1423 minus 2.88081
+....\glue 0.0 plus 0.93489
 ....\TU/FandolHei(0)/m/n/18.06749 要
 ....\kern -0.00017
 ....\kern 0.00017
@@ -792,7 +792,9 @@ Completed box being shipped out [1]
 ...\hbox(13.18927+3.10759)x417.11752, glue set 181.45753fil
 ....\glue(\leftskip) 0.0 plus 1.0fil
 ....\TU/FandolHei(0)/m/n/18.06749 目
-....\glue 18.06749 plus 0.1423 minus 2.88081
+....\kern -0.00017
+....\kern 0.00017
+....\glue 18.06749
 ....\TU/FandolHei(0)/m/n/18.06749 录
 ....\kern -0.00017
 ....\kern 0.00017
@@ -1292,15 +1294,21 @@ Completed box being shipped out [1]
 ...\glue(\parskip) 0.0
 ...\glue(\parskip) 0.0
 ...\glue(\baselineskip) 0.00002
-...\hbox(14.05243+6.02255)x417.11752, glue set 359.9038fill
+...\hbox(14.05243+6.02255)x417.11752, glue set 341.83632fill
 ....\hbox(0.0+0.0)x0.0
 ....\rule(14.05243+6.02255)x0.0
 ....\TU/FandolSong(0)/b/n/12.045 参
-....\glue 0.0 plus 0.61353
+....\kern -0.00017
+....\kern 0.00017
+....\kern 6.02249
 ....\TU/FandolSong(0)/b/n/12.045 考
-....\glue 0.0 plus 0.61353
+....\kern -0.00017
+....\kern 0.00017
+....\kern 6.02249
 ....\TU/FandolSong(0)/b/n/12.045 文
-....\glue 0.0 plus 0.61353
+....\kern -0.00017
+....\kern 0.00017
+....\kern 6.02249
 ....\TU/FandolSong(0)/b/n/12.045 献
 ....\kern -0.00017
 ....\kern 0.00017
@@ -1388,11 +1396,13 @@ Completed box being shipped out [1]
 ...\glue(\parskip) 0.0
 ...\glue(\parskip) 0.0
 ...\glue(\baselineskip) 0.00002
-...\hbox(14.05243+6.02255)x417.11752, glue set 377.9713fill
+...\hbox(14.05243+6.02255)x417.11752, glue set 365.9263fill
 ....\hbox(0.0+0.0)x0.0
 ....\rule(14.05243+6.02255)x0.0
 ....\TU/FandolSong(0)/b/n/12.045 致
-....\glue 0.0 plus 0.61353
+....\kern -0.00017
+....\kern 0.00017
+....\glue 12.045
 ....\TU/FandolSong(0)/b/n/12.045 谢
 ....\kern -0.00017
 ....\kern 0.00017
@@ -1832,14 +1842,14 @@ Completed box being shipped out [3]
 ...\glue(\parskip) 0.0
 ...\glue(\parskip) 0.0
 ...\glue(\baselineskip) 19.13951
-...\hbox(13.98424+3.14372)x417.11752, glue set 158.87318fil
+...\hbox(13.98424+3.14372)x417.11752, glue set 172.42378fil
 ....\glue(\leftskip) 0.0 plus 1.0fil
 ....\TU/FandolHei(0)/m/n/18.06749 符
-....\glue 9.03374 plus 1.40234 minus 0.4979
+....\glue 0.0 plus 0.93489
 ....\TU/FandolHei(0)/m/n/18.06749 号
-....\glue 9.03374 plus 1.40234 minus 0.4979
+....\glue 0.0 plus 0.93489
 ....\TU/FandolHei(0)/m/n/18.06749 说
-....\glue 9.03374 plus 1.40234 minus 0.4979
+....\glue 0.0 plus 0.93489
 ....\TU/FandolHei(0)/m/n/18.06749 明
 ....\kern -0.00017
 ....\kern 0.00017
@@ -4968,7 +4978,7 @@ Completed box being shipped out [8]
 ..\glue(\lineskip) 0.0
 ..\vbox(700.50723+0.0)x417.11752, glue set 586.44757fil
 ...\write-{}
-...\write2{\@writefile{toc}{\protect \contentsline {chapter}{参考文献}{\thepage }{}\protected@file@percent }}
+...\write2{\@writefile{toc}{\protect \contentsline {chapter}{参\protect \enspace  考\protect \enspace  文\protect \enspace  献}{\thepage }{}\protected@file@percent }}
 ...\glue(\topskip) 12.0
 ...\rule(0.0+0.0)x*
 ...\penalty 10000
@@ -4980,11 +4990,17 @@ Completed box being shipped out [8]
 ...\hbox(14.18298+3.39667)x417.11752, glue set 158.87318fil
 ....\glue(\leftskip) 0.0 plus 1.0fil
 ....\TU/FandolHei(0)/m/n/18.06749 参
-....\glue 9.03374 plus 1.40234 minus 0.4979
+....\kern -0.00017
+....\kern 0.00017
+....\kern 9.03374
 ....\TU/FandolHei(0)/m/n/18.06749 考
-....\glue 9.03374 plus 1.40234 minus 0.4979
+....\kern -0.00017
+....\kern 0.00017
+....\kern 9.03374
 ....\TU/FandolHei(0)/m/n/18.06749 文
-....\glue 9.03374 plus 1.40234 minus 0.4979
+....\kern -0.00017
+....\kern 0.00017
+....\kern 9.03374
 ....\TU/FandolHei(0)/m/n/18.06749 献
 ....\kern -0.00017
 ....\kern 0.00017
@@ -5384,7 +5400,7 @@ Completed box being shipped out [10]
 ..\vbox(700.50723+0.0)x417.11752, glue set 566.9528fil
 ...\write-{}
 ...\write-{}
-...\write2{\@writefile{toc}{\protect \contentsline {chapter}{致谢}{\thepage }{}\protected@file@percent }}
+...\write2{\@writefile{toc}{\protect \contentsline {chapter}{致\hskip 1em\relax 谢}{\thepage }{}\protected@file@percent }}
 ...\glue(\topskip) 12.0
 ...\rule(0.0+0.0)x*
 ...\penalty 10000
@@ -5396,7 +5412,9 @@ Completed box being shipped out [10]
 ...\hbox(13.98424+3.30634)x417.11752, glue set 181.45753fil
 ....\glue(\leftskip) 0.0 plus 1.0fil
 ....\TU/FandolHei(0)/m/n/18.06749 致
-....\glue 18.06749 plus 0.1423 minus 2.88081
+....\kern -0.00017
+....\kern 0.00017
+....\glue 18.06749
 ....\TU/FandolHei(0)/m/n/18.06749 谢
 ....\kern -0.00017
 ....\kern 0.00017

--- a/test/testfiles-crossref/main-bachelor-english.tlg
+++ b/test/testfiles-crossref/main-bachelor-english.tlg
@@ -83,7 +83,7 @@ Completed box being shipped out [1]
 ....\special{color pop}
 ..\glue 15.6491
 ..\glue(\lineskip) 0.0
-..\vbox(700.50723+0.0)x417.11752, glue set 494.52197fil
+..\vbox(700.50723+0.0)x417.11752, glue set 506.56564fil
 ...\write-{}
 ...\write-{}
 ...\write-{}
@@ -111,7 +111,7 @@ Completed box being shipped out [1]
 ...\glue 19.07124
 ...\glue(\parskip) 0.0
 ...\glue(\parskip) 0.0
-...\glue(\baselineskip) 9.54367
+...\glue(\baselineskip) 7.53618
 ...\hbox(9.3951+2.32468)x417.11752, glue set 0.41225
 ....\hbox(0.0+0.0)x24.09
 ....\TU/FandolSong(0)/m/n/12.045 研
@@ -181,7 +181,7 @@ Completed box being shipped out [1]
 ....\TU/FandolSong(0)/m/n/12.045 研
 ....\glue(\rightskip) 0.0
 ...\penalty 10150
-...\glue(\baselineskip) 10.36272
+...\glue(\baselineskip) 8.35522
 ...\hbox(9.3951+2.32468)x417.11752, glue set 99.65955fil
 ....\TU/FandolSong(0)/m/n/12.045 究
 ....\glue 0.0 plus 0.61353
@@ -248,7 +248,7 @@ Completed box being shipped out [1]
 ....\glue(\rightskip) 0.0
 ...\glue(\parskip) 0.0
 ...\glue(\parskip) 0.0
-...\glue(\baselineskip) 15.51797
+...\glue(\baselineskip) 13.51048
 ...\hbox(4.23984+0.0)x417.11752, glue set 370.98518fil
 ....\hbox(0.0+0.0)x24.09
 ....\penalty 0
@@ -264,11 +264,11 @@ Completed box being shipped out [1]
 ....\penalty 10000
 ....\glue(\parfillskip) 0.0 plus 1.0fil
 ....\glue(\rightskip) 0.0
-...\glue(\baselineskip) 22.08249
+...\glue(\baselineskip) 20.075
 ...\hbox(0.0+0.0)x0.0
 ...\glue(\parskip) 0.0
 ...\glue(\parskip) 0.0
-...\glue(\baselineskip) 12.6874
+...\glue(\baselineskip) 10.6799
 ...\hbox(9.3951+2.21626)x417.11752, glue set - 0.03065
 ....\TU/FandolSong(0)/b/n/12.045 关
 ....\glue 0.0 plus 0.61353
@@ -357,7 +357,7 @@ Completed box being shipped out [1]
 ....\TU/FandolSong(0)/m/n/12.045 键
 ....\glue(\rightskip) 0.0
 ...\penalty 300
-...\glue(\baselineskip) 10.59158
+...\glue(\baselineskip) 8.58409
 ...\hbox(9.27464+2.21626)x368.93753, glue set 290.64503fil, shifted 48.18
 ....\TU/FandolSong(0)/m/n/12.045 词
 ....\glue 3.01125 plus 1.50562 minus 1.00374
@@ -382,14 +382,14 @@ Completed box being shipped out [1]
 ...\glue 0.0 plus 1.0fil
 ...\glue 0.0
 ...\glue 0.0 plus 0.0001fil
-..\glue(\baselineskip) 15.85268
-..\hbox(6.6248+0.0)x417.11752
+..\glue(\baselineskip) 16.45493
+..\hbox(6.02255+0.0)x417.11752
 ...\special{color push  Black}
-...\hbox(6.6248+0.0)x417.11752
-....\hbox(6.6248+0.0)x417.11752
-.....\vbox(6.6248+0.0)x417.11752
+...\hbox(6.02255+0.0)x417.11752
+....\hbox(6.02255+0.0)x417.11752
+.....\vbox(6.02255+0.0)x417.11752
 ......\rule(0.0+0.0)x417.11752
-......\glue 6.6248
+......\glue 6.02255
 ......\hbox(0.0+0.0)x417.11752
 .......\hbox(0.0+0.0)x0.0, glue set - 417.11752fil
 ........\vbox(0.0+0.0)x417.11752
@@ -494,7 +494,7 @@ Completed box being shipped out [2]
 ....\special{color pop}
 ..\glue 15.6491
 ..\glue(\lineskip) 0.0
-..\vbox(700.50723+0.0)x417.11752, glue set 472.03236fil
+..\vbox(700.50723+0.0)x417.11752, glue set 486.0833fil
 ...\write-{}
 ...\write-{}
 ...\glue(\topskip) 12.0
@@ -517,7 +517,7 @@ Completed box being shipped out [2]
 ...\glue 19.07124
 ...\glue(\parskip) 0.0
 ...\glue(\parskip) 0.0
-...\glue(\baselineskip) 13.60283
+...\glue(\baselineskip) 11.59534
 ...\hbox(8.22673+2.6258)x417.11752, glue set 0.27924
 ....\hbox(0.0+0.0)x24.09
 ....\TU/texgyretermes(0)/m/n/12.045 Graduate
@@ -545,7 +545,7 @@ Completed box being shipped out [2]
 ....\TU/texgyretermes(0)/m/n/12.045 re-
 ....\glue(\rightskip) 0.0
 ...\penalty 250
-...\glue(\baselineskip) 11.22997
+...\glue(\baselineskip) 9.22247
 ...\hbox(8.22673+2.6258)x417.11752, glue set 0.71335
 ....\TU/texgyretermes(0)/m/n/12.045 flection,
 ....\glue 3.01125 plus 1.88202 minus 0.80298
@@ -578,7 +578,7 @@ Completed box being shipped out [2]
 ....\TU/texgyretermes(0)/m/n/12.045 of
 ....\glue(\rightskip) 0.0
 ...\penalty 150
-...\glue(\baselineskip) 11.22997
+...\glue(\baselineskip) 9.22247
 ...\hbox(8.22673+2.6258)x417.11752, glue set 193.466fil
 ....\TU/texgyretermes(0)/m/n/12.045 application
 ....\glue 3.01125 plus 1.50562 minus 1.00374
@@ -596,18 +596,18 @@ Completed box being shipped out [2]
 ....\glue(\rightskip) 0.0
 ...\glue(\parskip) 0.0
 ...\glue(\parskip) 0.0
-...\glue(\baselineskip) 18.2522
+...\glue(\baselineskip) 16.2447
 ...\hbox(1.2045+0.13248)x417.11752, glue set 380.98253fil
 ....\hbox(0.0+0.0)x24.09
 ....\TU/texgyretermes(0)/m/n/12.045 …
 ....\penalty 10000
 ....\glue(\parfillskip) 0.0 plus 1.0fil
 ....\glue(\rightskip) 0.0
-...\glue(\baselineskip) 21.95001
+...\glue(\baselineskip) 19.94252
 ...\hbox(0.0+0.0)x0.0
 ...\glue(\parskip) 0.0
 ...\glue(\parskip) 0.0
-...\glue(\baselineskip) 13.79553
+...\glue(\baselineskip) 11.78804
 ...\hbox(8.28696+2.6258)x417.11752, glue set - 0.68094
 ....\TU/texgyretermes(0)/b/n/12.045 Key
 ....\glue 3.01125 plus 1.50562 minus 1.00374
@@ -642,7 +642,7 @@ Completed box being shipped out [2]
 ....\TU/texgyretermes(0)/m/n/12.045 Keyword
 ....\glue(\rightskip) 0.0
 ...\penalty 300
-...\glue(\baselineskip) 11.21791
+...\glue(\baselineskip) 9.21042
 ...\hbox(8.23878+2.6258)x338.82504, glue set 208.40184fil, shifted 78.29248
 ....\TU/texgyretermes(0)/m/n/12.045 6;
 ....\glue 3.01125 plus 2.25842 minus 0.66916
@@ -663,15 +663,15 @@ Completed box being shipped out [2]
 ...\glue 0.0 plus 1.0fil
 ...\glue 0.0
 ...\glue 0.0 plus 0.0001fil
-..\glue(\baselineskip) 15.85268
-..\hbox(6.6248+0.0)x417.11752
+..\glue(\baselineskip) 16.45493
+..\hbox(6.02255+0.0)x417.11752
 ...\special{color push  Black}
-...\hbox(6.6248+0.0)x417.11752
+...\hbox(6.02255+0.0)x417.11752
 ....\glue 0.0 plus 1.0fil minus 1.0fil
-....\hbox(6.6248+0.0)x417.11752
-.....\vbox(6.6248+0.0)x417.11752
+....\hbox(6.02255+0.0)x417.11752
+.....\vbox(6.02255+0.0)x417.11752
 ......\rule(0.0+0.0)x417.11752
-......\glue 6.6248
+......\glue 6.02255
 ......\hbox(0.0+0.0)x417.11752
 .......\hbox(0.0+0.0)x0.0, glue set - 417.11752fil
 ........\vbox(0.0+0.0)x417.11752
@@ -777,7 +777,7 @@ Completed box being shipped out [1]
 ....\special{color pop}
 ..\glue 15.6491
 ..\glue(\lineskip) 0.0
-..\vbox(700.50723+0.0)x417.11752, glue set 321.50198fil
+..\vbox(700.50723+0.0)x417.11752, glue set 346.19151fil
 ...\write-{}
 ...\write-{}
 ...\write-{}
@@ -804,11 +804,11 @@ Completed box being shipped out [1]
 ...\penalty 10000
 ...\glue(\parskip) 0.0
 ...\glue(\parskip) 0.0
-...\glue(\baselineskip) 6.29962
-...\hbox(15.45767+6.6248)x417.11752, glue set 324.78058fill
+...\glue(\baselineskip) 5.69737
+...\hbox(14.05243+6.02255)x417.11752, glue set 324.78058fill
 ....\glue(\leftskip) 59.21321
 ....\hbox(0.0+0.0)x0.0
-....\rule(15.45767+6.6248)x0.0
+....\rule(14.05243+6.02255)x0.0
 ....\hbox(8.22673+2.61375)x0.0, glue set - 59.21321fil
 .....\glue 0.0 plus 1.0fil minus 1.0fil
 .....\hbox(8.22673+2.61375)x59.21321
@@ -825,7 +825,7 @@ Completed box being shipped out [1]
 ....\TU/FandolSong(0)/m/n/12.045 言
 ....\kern -0.00017
 ....\kern 0.00017
-....\rule(15.45767+6.6248)x0.0
+....\rule(14.05243+6.02255)x0.0
 ....\kern 0.0
 ....\glue 2.00749
 ....\glue -4.015
@@ -854,10 +854,10 @@ Completed box being shipped out [1]
 ...\glue(\parskip) 0.0
 ...\glue(\parskip) 0.0
 ...\glue(\baselineskip) 0.00002
-...\hbox(15.45767+6.6248)x417.11752, glue set 224.39757fill
+...\hbox(14.05243+6.02255)x417.11752, glue set 224.39757fill
 ....\glue(\leftskip) 39.14624
 ....\hbox(0.0+0.0)x0.0
-....\rule(15.45767+6.6248)x0.0
+....\rule(14.05243+6.02255)x0.0
 ....\hbox(8.14243+0.13248)x0.0, glue set - 27.10124fil
 .....\glue 0.0 plus 1.0fil minus 1.0fil
 .....\hbox(8.14243+0.13248)x27.10124
@@ -892,7 +892,7 @@ Completed box being shipped out [1]
 ....\TU/FandolSong(0)/m/n/12.045 析
 ....\kern -0.00017
 ....\kern 0.00017
-....\rule(15.45767+6.6248)x0.0
+....\rule(14.05243+6.02255)x0.0
 ....\kern 0.0
 ....\glue 2.00749
 ....\glue -4.015
@@ -921,10 +921,10 @@ Completed box being shipped out [1]
 ...\glue(\parskip) 0.0
 ...\glue(\parskip) 0.0
 ...\glue(\baselineskip) 0.00002
-...\hbox(15.45767+6.6248)x417.11752, glue set 275.5888fill
+...\hbox(14.05243+6.02255)x417.11752, glue set 275.5888fill
 ....\glue(\leftskip) 60.22499
 ....\hbox(0.0+0.0)x0.0
-....\rule(15.45767+6.6248)x0.0
+....\rule(14.05243+6.02255)x0.0
 ....\hbox(8.14243+0.13248)x0.0, glue set - 36.135fil
 .....\glue 0.0 plus 1.0fil minus 1.0fil
 .....\hbox(8.14243+0.13248)x36.135
@@ -947,7 +947,7 @@ Completed box being shipped out [1]
 ....\TU/FandolSong(0)/m/n/12.045 题
 ....\kern -0.00017
 ....\kern 0.00017
-....\rule(15.45767+6.6248)x0.0
+....\rule(14.05243+6.02255)x0.0
 ....\kern 0.0
 ....\glue 2.00749
 ....\glue -4.015
@@ -980,10 +980,10 @@ Completed box being shipped out [1]
 ...\glue(\parskip) 0.0
 ...\glue(\parskip) 0.0
 ...\glue(\baselineskip) 0.00002
-...\hbox(15.45767+6.6248)x417.11752, glue set 300.69058fill
+...\hbox(14.05243+6.02255)x417.11752, glue set 300.69058fill
 ....\glue(\leftskip) 59.21321
 ....\hbox(0.0+0.0)x0.0
-....\rule(15.45767+6.6248)x0.0
+....\rule(14.05243+6.02255)x0.0
 ....\hbox(8.22673+2.61375)x0.0, glue set - 59.21321fil
 .....\glue 0.0 plus 1.0fil minus 1.0fil
 .....\hbox(8.22673+2.61375)x59.21321
@@ -1004,7 +1004,7 @@ Completed box being shipped out [1]
 ....\TU/FandolSong(0)/m/n/12.045 素
 ....\kern -0.00017
 ....\kern 0.00017
-....\rule(15.45767+6.6248)x0.0
+....\rule(14.05243+6.02255)x0.0
 ....\kern 0.0
 ....\glue 2.00749
 ....\glue -4.015
@@ -1033,10 +1033,10 @@ Completed box being shipped out [1]
 ...\glue(\parskip) 0.0
 ...\glue(\parskip) 0.0
 ...\glue(\baselineskip) 0.00002
-...\hbox(15.45767+6.6248)x417.11752, glue set 260.53256fill
+...\hbox(14.05243+6.02255)x417.11752, glue set 260.53256fill
 ....\glue(\leftskip) 39.14624
 ....\hbox(0.0+0.0)x0.0
-....\rule(15.45767+6.6248)x0.0
+....\rule(14.05243+6.02255)x0.0
 ....\hbox(8.14243+0.13248)x0.0, glue set - 27.10124fil
 .....\glue 0.0 plus 1.0fil minus 1.0fil
 .....\hbox(8.14243+0.13248)x27.10124
@@ -1067,7 +1067,7 @@ Completed box being shipped out [1]
 ....\TU/FandolSong(0)/m/n/12.045 式
 ....\kern -0.00017
 ....\kern 0.00017
-....\rule(15.45767+6.6248)x0.0
+....\rule(14.05243+6.02255)x0.0
 ....\kern 0.0
 ....\glue 2.00749
 ....\glue -4.015
@@ -1096,10 +1096,10 @@ Completed box being shipped out [1]
 ...\glue(\parskip) 0.0
 ...\glue(\parskip) 0.0
 ...\glue(\baselineskip) 0.00002
-...\hbox(15.45767+6.6248)x417.11752, glue set 323.7688fill
+...\hbox(14.05243+6.02255)x417.11752, glue set 323.7688fill
 ....\glue(\leftskip) 60.22499
 ....\hbox(0.0+0.0)x0.0
-....\rule(15.45767+6.6248)x0.0
+....\rule(14.05243+6.02255)x0.0
 ....\hbox(8.14243+0.13248)x0.0, glue set - 36.135fil
 .....\glue 0.0 plus 1.0fil minus 1.0fil
 .....\hbox(8.14243+0.13248)x36.135
@@ -1114,7 +1114,7 @@ Completed box being shipped out [1]
 ....\TU/FandolSong(0)/m/n/12.045 图
 ....\kern -0.00017
 ....\kern 0.00017
-....\rule(15.45767+6.6248)x0.0
+....\rule(14.05243+6.02255)x0.0
 ....\kern 0.0
 ....\glue 2.00749
 ....\glue -4.015
@@ -1143,10 +1143,10 @@ Completed box being shipped out [1]
 ...\glue(\parskip) 0.0
 ...\glue(\parskip) 0.0
 ...\glue(\baselineskip) 0.00002
-...\hbox(15.45767+6.6248)x417.11752, glue set 323.7688fill
+...\hbox(14.05243+6.02255)x417.11752, glue set 323.7688fill
 ....\glue(\leftskip) 60.22499
 ....\hbox(0.0+0.0)x0.0
-....\rule(15.45767+6.6248)x0.0
+....\rule(14.05243+6.02255)x0.0
 ....\hbox(8.14243+0.13248)x0.0, glue set - 36.135fil
 .....\glue 0.0 plus 1.0fil minus 1.0fil
 .....\hbox(8.14243+0.13248)x36.135
@@ -1161,7 +1161,7 @@ Completed box being shipped out [1]
 ....\TU/FandolSong(0)/m/n/12.045 格
 ....\kern -0.00017
 ....\kern 0.00017
-....\rule(15.45767+6.6248)x0.0
+....\rule(14.05243+6.02255)x0.0
 ....\kern 0.0
 ....\glue 2.00749
 ....\glue -4.015
@@ -1190,10 +1190,10 @@ Completed box being shipped out [1]
 ...\glue(\parskip) 0.0
 ...\glue(\parskip) 0.0
 ...\glue(\baselineskip) 0.00002
-...\hbox(15.45767+6.6248)x417.11752, glue set 311.7238fill
+...\hbox(14.05243+6.02255)x417.11752, glue set 311.7238fill
 ....\glue(\leftskip) 60.22499
 ....\hbox(0.0+0.0)x0.0
-....\rule(15.45767+6.6248)x0.0
+....\rule(14.05243+6.02255)x0.0
 ....\hbox(8.14243+0.16861)x0.0, glue set - 36.135fil
 .....\glue 0.0 plus 1.0fil minus 1.0fil
 .....\hbox(8.14243+0.16861)x36.135
@@ -1210,7 +1210,60 @@ Completed box being shipped out [1]
 ....\TU/FandolSong(0)/m/n/12.045 式
 ....\kern -0.00017
 ....\kern 0.00017
-....\rule(15.45767+6.6248)x0.0
+....\rule(14.05243+6.02255)x0.0
+....\kern 0.0
+....\glue 2.00749
+....\glue -4.015
+....\glue 3.01125
+....\leaders 0.0 plus 1.0fill
+.....\hbox(1.2045+0.13248)x4.015, glue set 1.00375fil
+......\glue 0.0 plus 1.0fil minus 1.0fil
+......\hbox(1.2045+0.13248)x3.01125
+.......\special{color push  Black}
+.......\TU/texgyretermes(0)/m/n/12.045 .
+.......\kern -0.0002
+.......\kern 0.0002
+.......\special{color pop}
+....\kern 0.0
+....\glue 2.00749
+....\TU/texgyretermes(0)/m/n/12.045 6
+....\kern -0.0002
+....\kern 0.0002
+....\penalty 10000
+....\glue(\parfillskip) 0.0 plus 1.0fil
+....\glue(\rightskip) 0.0
+...\penalty 10000
+...\glue 12.045
+...\glue -18.045
+...\penalty -300
+...\glue 6.0
+...\glue 12.045
+...\glue 0.0 plus 0.1
+...\penalty 10000
+...\glue(\parskip) 0.0
+...\glue(\parskip) 0.0
+...\glue(\baselineskip) 0.00002
+...\hbox(14.05243+6.02255)x417.11752, glue set 324.78058fill
+....\glue(\leftskip) 59.21321
+....\hbox(0.0+0.0)x0.0
+....\rule(14.05243+6.02255)x0.0
+....\hbox(8.22673+2.61375)x0.0, glue set - 59.21321fil
+.....\glue 0.0 plus 1.0fil minus 1.0fil
+.....\hbox(8.22673+2.61375)x59.21321
+......\special{color push  Black}
+......\TU/texgyretermes(0)/m/n/12.045 Chapter
+......\glue 3.01125 plus 1.50562 minus 1.00374
+......\TU/texgyretermes(0)/m/n/12.045 3
+......\kern -0.0002
+......\kern 0.0002
+......\glue 12.045
+......\special{color pop}
+....\TU/FandolSong(0)/m/n/12.045 引
+....\glue 0.0 plus 0.61353
+....\TU/FandolSong(0)/m/n/12.045 用
+....\kern -0.00017
+....\kern 0.00017
+....\rule(14.05243+6.02255)x0.0
 ....\kern 0.0
 ....\glue 2.00749
 ....\glue -4.015
@@ -1235,7 +1288,7 @@ Completed box being shipped out [1]
 ...\penalty 10000
 ...\glue 12.045
 ...\glue -18.045
-...\penalty -300
+...\penalty 0
 ...\glue 6.0
 ...\glue 12.045
 ...\glue 0.0 plus 0.1
@@ -1243,27 +1296,13 @@ Completed box being shipped out [1]
 ...\glue(\parskip) 0.0
 ...\glue(\parskip) 0.0
 ...\glue(\baselineskip) 0.00002
-...\hbox(15.45767+6.6248)x417.11752, glue set 324.78058fill
-....\glue(\leftskip) 59.21321
+...\hbox(14.05243+6.02255)x417.11752, glue set 344.75117fill
 ....\hbox(0.0+0.0)x0.0
-....\rule(15.45767+6.6248)x0.0
-....\hbox(8.22673+2.61375)x0.0, glue set - 59.21321fil
-.....\glue 0.0 plus 1.0fil minus 1.0fil
-.....\hbox(8.22673+2.61375)x59.21321
-......\special{color push  Black}
-......\TU/texgyretermes(0)/m/n/12.045 Chapter
-......\glue 3.01125 plus 1.50562 minus 1.00374
-......\TU/texgyretermes(0)/m/n/12.045 3
-......\kern -0.0002
-......\kern 0.0002
-......\glue 12.045
-......\special{color pop}
-....\TU/FandolSong(0)/m/n/12.045 引
-....\glue 0.0 plus 0.61353
-....\TU/FandolSong(0)/m/n/12.045 用
-....\kern -0.00017
-....\kern 0.00017
-....\rule(15.45767+6.6248)x0.0
+....\rule(14.05243+6.02255)x0.0
+....\TU/texgyretermes(0)/m/n/12.045 Bibliography
+....\kern -0.0002
+....\kern 0.0002
+....\rule(14.05243+6.02255)x0.0
 ....\kern 0.0
 ....\glue 2.00749
 ....\glue -4.015
@@ -1286,23 +1325,37 @@ Completed box being shipped out [1]
 ....\glue(\parfillskip) 0.0 plus 1.0fil
 ....\glue(\rightskip) 0.0
 ...\penalty 10000
-...\glue 12.045
-...\glue -18.045
 ...\penalty 0
-...\glue 6.0
-...\glue 12.045
 ...\glue 0.0 plus 0.1
 ...\penalty 10000
 ...\glue(\parskip) 0.0
 ...\glue(\parskip) 0.0
 ...\glue(\baselineskip) 0.00002
-...\hbox(15.45767+6.6248)x417.11752, glue set 344.75117fill
+...\hbox(14.05243+6.02255)x417.11752, glue set 288.64558fill
+....\glue(\leftskip) 71.25821
 ....\hbox(0.0+0.0)x0.0
-....\rule(15.45767+6.6248)x0.0
-....\TU/texgyretermes(0)/m/n/12.045 Bibliography
-....\kern -0.0002
-....\kern 0.0002
-....\rule(15.45767+6.6248)x0.0
+....\rule(14.05243+6.02255)x0.0
+....\hbox(8.22673+2.61375)x0.0, glue set - 71.25821fil
+.....\glue 0.0 plus 1.0fil minus 1.0fil
+.....\hbox(8.22673+2.61375)x71.25821
+......\special{color push  Black}
+......\TU/texgyretermes(0)/m/n/12.045 Appendix
+......\glue 3.01125 plus 1.50562 minus 1.00374
+......\TU/texgyretermes(0)/m/n/12.045 A
+......\kern -0.0002
+......\kern 0.0002
+......\glue 12.045
+......\special{color pop}
+....\TU/FandolSong(0)/m/n/12.045 附
+....\glue 0.0 plus 0.61353
+....\TU/FandolSong(0)/m/n/12.045 录
+....\glue 0.0 plus 0.61353
+....\TU/FandolSong(0)/m/n/12.045 章
+....\glue 0.0 plus 0.61353
+....\TU/FandolSong(0)/m/n/12.045 节
+....\kern -0.00017
+....\kern 0.00017
+....\rule(14.05243+6.02255)x0.0
 ....\kern 0.0
 ....\glue 2.00749
 ....\glue -4.015
@@ -1331,31 +1384,13 @@ Completed box being shipped out [1]
 ...\glue(\parskip) 0.0
 ...\glue(\parskip) 0.0
 ...\glue(\baselineskip) 0.00002
-...\hbox(15.45767+6.6248)x417.11752, glue set 282.6231fill
-....\glue(\leftskip) 71.25821
+...\hbox(14.05243+6.02255)x417.11752, glue set 308.1344fill
 ....\hbox(0.0+0.0)x0.0
-....\rule(15.45767+6.6248)x0.0
-....\hbox(8.22673+2.61375)x0.0, glue set - 71.25821fil
-.....\glue 0.0 plus 1.0fil minus 1.0fil
-.....\hbox(8.22673+2.61375)x71.25821
-......\special{color push  Black}
-......\TU/texgyretermes(0)/m/n/12.045 Appendix
-......\glue 3.01125 plus 1.50562 minus 1.00374
-......\TU/texgyretermes(0)/m/n/12.045 A
-......\kern -0.0002
-......\kern 0.0002
-......\glue 12.045
-......\special{color pop}
-....\TU/FandolSong(0)/m/n/12.045 附
-....\glue 0.0 plus 0.61353
-....\TU/FandolSong(0)/m/n/12.045 录
-....\glue 0.0 plus 0.61353
-....\TU/FandolSong(0)/m/n/12.045 章
-....\glue 0.0 plus 0.61353
-....\TU/FandolSong(0)/m/n/12.045 节
-....\kern -0.00017
-....\kern 0.00017
-....\rule(15.45767+6.6248)x0.0
+....\rule(14.05243+6.02255)x0.0
+....\TU/texgyretermes(0)/m/n/12.045 Acknowledgements
+....\kern -0.0002
+....\kern 0.0002
+....\rule(14.05243+6.02255)x0.0
 ....\kern 0.0
 ....\glue 2.00749
 ....\glue -4.015
@@ -1378,52 +1413,17 @@ Completed box being shipped out [1]
 ....\glue(\parfillskip) 0.0 plus 1.0fil
 ....\glue(\rightskip) 0.0
 ...\penalty 10000
-...\penalty 0
-...\glue 0.0 plus 0.1
-...\penalty 10000
-...\glue(\parskip) 0.0
-...\glue(\parskip) 0.0
-...\glue(\baselineskip) 0.00002
-...\hbox(15.45767+6.6248)x417.11752, glue set 308.1344fill
-....\hbox(0.0+0.0)x0.0
-....\rule(15.45767+6.6248)x0.0
-....\TU/texgyretermes(0)/m/n/12.045 Acknowledgements
-....\kern -0.0002
-....\kern 0.0002
-....\rule(15.45767+6.6248)x0.0
-....\kern 0.0
-....\glue 2.00749
-....\glue -4.015
-....\glue 3.01125
-....\leaders 0.0 plus 1.0fill
-.....\hbox(1.2045+0.13248)x4.015, glue set 1.00375fil
-......\glue 0.0 plus 1.0fil minus 1.0fil
-......\hbox(1.2045+0.13248)x3.01125
-.......\special{color push  Black}
-.......\TU/texgyretermes(0)/m/n/12.045 .
-.......\kern -0.0002
-.......\kern 0.0002
-.......\special{color pop}
-....\kern 0.0
-....\glue 2.00749
-....\TU/texgyretermes(0)/m/n/12.045 11
-....\kern -0.0002
-....\kern 0.0002
-....\penalty 10000
-....\glue(\parfillskip) 0.0 plus 1.0fil
-....\glue(\rightskip) 0.0
-...\penalty 10000
 ...\glue 0.0 plus 1.0fil
 ...\glue 0.0
 ...\glue 0.0 plus 0.0001fil
-..\glue(\baselineskip) 7.63202
-..\hbox(14.84546+3.5232)x417.11752
+..\glue(\baselineskip) 8.23427
+..\hbox(14.24321+3.5232)x417.11752
 ...\special{color push  Black}
-...\hbox(14.84546+3.5232)x417.11752
-....\hbox(14.84546+3.5232)x417.11752
-.....\vbox(14.84546+3.5232)x417.11752
+...\hbox(14.24321+3.5232)x417.11752
+....\hbox(14.24321+3.5232)x417.11752
+.....\vbox(14.24321+3.5232)x417.11752
 ......\rule(0.0+0.0)x417.11752
-......\glue 6.6248
+......\glue 6.02255
 ......\hbox(8.22066+3.5232)x417.11752
 .......\hbox(0.0+0.0)x0.0, glue set - 417.11752fil
 ........\vbox(0.0+0.0)x417.11752
@@ -1536,7 +1536,7 @@ Completed box being shipped out [2]
 ....\special{color pop}
 ..\glue 15.6491
 ..\glue(\lineskip) 0.0
-..\vbox(700.50723+0.0)x417.11752, glue set 578.43443fil
+..\vbox(700.50723+0.0)x417.11752, glue set 583.05118fil
 ...\write-{}
 ...\write-{}
 ...\glue(\topskip) 12.0
@@ -1569,11 +1569,11 @@ Completed box being shipped out [2]
 ...\penalty 10000
 ...\glue(\parskip) 0.0
 ...\glue(\parskip) 0.0
-...\glue(\baselineskip) 2.68613
-...\hbox(15.45767+6.6248)x417.11752, glue set 250.3425fill
+...\glue(\baselineskip) 2.08388
+...\hbox(14.05243+6.02255)x417.11752, glue set 250.3425fill
 ....\glue(\leftskip) 61.3813
 ....\hbox(0.0+0.0)x0.0
-....\rule(15.45767+6.6248)x0.0
+....\rule(14.05243+6.02255)x0.0
 ....\hbox(8.14243+2.6258)x0.0, glue set - 61.3813fil
 .....\glue 0.0 plus 1.0fil minus 1.0fil
 .....\hbox(8.14243+2.6258)x61.3813
@@ -1605,7 +1605,7 @@ Completed box being shipped out [2]
 ....\TU/FandolSong(0)/m/n/12.045 方
 ....\kern -0.00017
 ....\kern 0.00017
-....\rule(15.45767+6.6248)x0.0
+....\rule(14.05243+6.02255)x0.0
 ....\kern 0.0
 ....\glue 2.00749
 ....\glue -4.015
@@ -1634,10 +1634,10 @@ Completed box being shipped out [2]
 ...\glue(\parskip) 0.0
 ...\glue(\parskip) 0.0
 ...\glue(\baselineskip) 0.00002
-...\hbox(15.45767+6.6248)x417.11752, glue set 255.08823fill
+...\hbox(14.05243+6.02255)x417.11752, glue set 255.08823fill
 ....\glue(\leftskip) 56.63557
 ....\hbox(0.0+0.0)x0.0
-....\rule(15.45767+6.6248)x0.0
+....\rule(14.05243+6.02255)x0.0
 ....\hbox(8.22673+0.13248)x0.0, glue set - 56.63557fil
 .....\glue 0.0 plus 1.0fil minus 1.0fil
 .....\hbox(8.22673+0.13248)x56.63557
@@ -1669,7 +1669,7 @@ Completed box being shipped out [2]
 ....\TU/FandolSong(0)/m/n/12.045 方
 ....\kern -0.00017
 ....\kern 0.00017
-....\rule(15.45767+6.6248)x0.0
+....\rule(14.05243+6.02255)x0.0
 ....\kern 0.0
 ....\glue 2.00749
 ....\glue -4.015
@@ -1695,15 +1695,15 @@ Completed box being shipped out [2]
 ...\glue 0.0 plus 1.0fil
 ...\glue 0.0
 ...\glue 0.0 plus 0.0001fil
-..\glue(\baselineskip) 7.63202
-..\hbox(14.84546+3.5232)x417.11752
+..\glue(\baselineskip) 8.23427
+..\hbox(14.24321+3.5232)x417.11752
 ...\special{color push  Black}
-...\hbox(14.84546+3.5232)x417.11752
+...\hbox(14.24321+3.5232)x417.11752
 ....\glue 0.0 plus 1.0fil minus 1.0fil
-....\hbox(14.84546+3.5232)x417.11752
-.....\vbox(14.84546+3.5232)x417.11752
+....\hbox(14.24321+3.5232)x417.11752
+.....\vbox(14.24321+3.5232)x417.11752
 ......\rule(0.0+0.0)x417.11752
-......\glue 6.6248
+......\glue 6.02255
 ......\hbox(8.22066+3.5232)x417.11752
 .......\hbox(0.0+0.0)x0.0, glue set - 417.11752fil
 ........\vbox(0.0+0.0)x417.11752
@@ -1811,7 +1811,7 @@ Completed box being shipped out [3]
 ....\special{color pop}
 ..\glue 15.6491
 ..\glue(\lineskip) 0.0
-..\vbox(700.50723+0.0)x417.11752, glue set 607.0062fil
+..\vbox(700.50723+0.0)x417.11752, glue set 609.01347fil
 ...\write-{}
 ...\write-{}
 ...\glue(\topskip) 12.0
@@ -1834,7 +1834,7 @@ Completed box being shipped out [3]
 ...\glue 19.07124
 ...\glue(\parskip) 0.0
 ...\glue(\parskip) 0.0
-...\glue(\baselineskip) 13.8377
+...\glue(\baselineskip) 11.83022
 ...\hbox(7.97379+0.13248)x417.11752, glue set 339.3992fil
 ....\hbox(0.0+0.0)x24.09
 ....\TU/texgyretermes(0)/m/n/12.045 Notations.
@@ -1845,14 +1845,14 @@ Completed box being shipped out [3]
 ...\glue 0.0 plus 1.0fil
 ...\glue 0.0
 ...\glue 0.0 plus 0.0001fil
-..\glue(\baselineskip) 7.63202
-..\hbox(14.84546+3.5232)x417.11752
+..\glue(\baselineskip) 8.23427
+..\hbox(14.24321+3.5232)x417.11752
 ...\special{color push  Black}
-...\hbox(14.84546+3.5232)x417.11752
-....\hbox(14.84546+3.5232)x417.11752
-.....\vbox(14.84546+3.5232)x417.11752
+...\hbox(14.24321+3.5232)x417.11752
+....\hbox(14.24321+3.5232)x417.11752
+.....\vbox(14.24321+3.5232)x417.11752
 ......\rule(0.0+0.0)x417.11752
-......\glue 6.6248
+......\glue 6.02255
 ......\hbox(8.22066+3.5232)x417.11752
 .......\hbox(0.0+0.0)x0.0, glue set - 417.11752fil
 ........\vbox(0.0+0.0)x417.11752
@@ -1962,7 +1962,7 @@ Completed box being shipped out [4]
 ....\special{color pop}
 ..\glue 15.6491
 ..\glue(\lineskip) 0.0
-..\vbox(700.50723+0.0)x417.11752, glue set 242.33476fil
+..\vbox(700.50723+0.0)x417.11752, glue set 268.42937fil
 ...\write-{}
 ...\write-{}
 ...\write2{\@writefile{toc}{\protect \addvspace {12bp}}}
@@ -1996,7 +1996,7 @@ Completed box being shipped out [4]
 ...\glue 19.07124
 ...\glue(\parskip) 0.0
 ...\glue(\parskip) 0.0
-...\glue(\baselineskip) 9.18633
+...\glue(\baselineskip) 7.17883
 ...\hbox(9.3951+2.32468)x417.11752, glue set 0.41225
 ....\hbox(0.0+0.0)x24.09
 ....\TU/FandolSong(0)/m/n/12.045 研
@@ -2066,7 +2066,7 @@ Completed box being shipped out [4]
 ....\TU/FandolSong(0)/m/n/12.045 依
 ....\glue(\rightskip) 0.0
 ...\penalty 10000
-...\glue(\baselineskip) 10.36272
+...\glue(\baselineskip) 8.35522
 ...\hbox(9.3951+2.32468)x417.11752, glue set - 0.2467
 ....\TU/FandolSong(0)/m/n/12.045 据
 ....\penalty 10000
@@ -2144,7 +2144,7 @@ Completed box being shipped out [4]
 ....\glue 0.0 plus 0.61353
 ....\TU/FandolSong(0)/m/n/12.045 提
 ....\glue(\rightskip) 0.0
-...\glue(\baselineskip) 10.35066
+...\glue(\baselineskip) 8.34317
 ...\hbox(9.40715+2.32468)x417.11752, glue set 0.38647
 ....\TU/FandolSong(0)/m/n/12.045 高
 ....\glue 0.0 plus 0.61353
@@ -2216,7 +2216,7 @@ Completed box being shipped out [4]
 ....\glue 0.0 plus 0.61353
 ....\TU/FandolSong(0)/m/n/12.045 同
 ....\glue(\rightskip) 0.0
-...\glue(\baselineskip) 10.36272
+...\glue(\baselineskip) 8.35522
 ...\hbox(9.3951+2.32468)x417.11752, glue set - 0.37006
 ....\TU/FandolSong(0)/m/n/12.045 努
 ....\glue 0.0 plus 0.61353
@@ -2293,7 +2293,7 @@ Completed box being shipped out [4]
 ....\TU/FandolSong(0)/m/n/12.045 问
 ....\glue(\rightskip) 0.0
 ...\penalty 150
-...\glue(\baselineskip) 10.31453
+...\glue(\baselineskip) 8.30704
 ...\hbox(9.44328+2.32468)x417.11752, glue set 135.79454fil
 ....\TU/FandolSong(0)/m/n/12.045 题
 ....\glue 0.0 plus 0.61353
@@ -2399,7 +2399,7 @@ Completed box being shipped out [4]
 ...\glue 6.02249
 ...\glue(\parskip) 0.0
 ...\glue(\parskip) 0.0
-...\glue(\baselineskip) 10.02245
+...\glue(\baselineskip) 8.01495
 ...\hbox(9.3951+2.32468)x417.11752, glue set 0.41225
 ....\hbox(0.0+0.0)x24.09
 ....\TU/FandolSong(0)/m/n/12.045 从
@@ -2469,7 +2469,7 @@ Completed box being shipped out [4]
 ....\TU/FandolSong(0)/m/n/12.045 这
 ....\glue(\rightskip) 0.0
 ...\penalty 10150
-...\glue(\baselineskip) 10.41089
+...\glue(\baselineskip) 8.4034
 ...\hbox(9.34692+2.16809)x417.11752, glue set 220.10953fil
 ....\TU/FandolSong(0)/m/n/12.045 两
 ....\glue 0.0 plus 0.61353
@@ -2544,7 +2544,7 @@ Completed box being shipped out [4]
 ...\glue 6.02249
 ...\glue(\parskip) 0.0
 ...\glue(\parskip) 0.0
-...\glue(\baselineskip) 10.31453
+...\glue(\baselineskip) 8.30704
 ...\hbox(9.40715+2.32468)x417.11752, glue set 0.42645
 ....\hbox(0.0+0.0)x24.09
 ....\TU/FandolSong(0)/m/n/12.045 文
@@ -2616,7 +2616,7 @@ Completed box being shipped out [4]
 ....\TU/FandolSong(0)/m/n/12.045 何
 ....\glue(\rightskip) 0.0
 ...\penalty 10000
-...\glue(\baselineskip) 10.35066
+...\glue(\baselineskip) 8.34317
 ...\hbox(9.40715+2.32468)x417.11752, glue set 0.17856
 ....\TU/FandolSong(0)/m/n/12.045 写
 ....\penalty 10000
@@ -2693,7 +2693,7 @@ Completed box being shipped out [4]
 ....\TU/FandolSong(0)/m/n/12.045 、
 ....\rule(0.0+0.0)x-7.85333
 ....\glue(\rightskip) 0.0
-...\glue(\baselineskip) 10.33862
+...\glue(\baselineskip) 8.33113
 ...\hbox(9.41919+2.32468)x417.11752, glue set - 0.33904
 ....\TU/FandolSong(0)/m/n/12.045 缩
 ....\glue 0.0 plus 0.61353
@@ -2776,7 +2776,7 @@ Completed box being shipped out [4]
 ....\TU/FandolSong(0)/m/n/12.045 ，
 ....\rule(0.0+0.0)x-8.33514
 ....\glue(\rightskip) 0.0
-...\glue(\baselineskip) 10.38681
+...\glue(\baselineskip) 8.37932
 ...\hbox(9.371+2.32468)x417.11752, glue set 0.1969
 ....\TU/FandolSong(0)/m/n/12.045 方
 ....\glue 0.0 plus 0.61353
@@ -2851,7 +2851,7 @@ Completed box being shipped out [4]
 ....\TU/FandolSong(0)/m/n/12.045 ；
 ....\rule(0.0+0.0)x-8.32309
 ....\glue(\rightskip) 0.0
-...\glue(\baselineskip) 10.36272
+...\glue(\baselineskip) 8.35522
 ...\hbox(9.3951+2.32468)x417.11752, glue set - 0.37006
 ....\TU/FandolSong(0)/m/n/12.045 有
 ....\glue 0.0 plus 0.61353
@@ -2928,7 +2928,7 @@ Completed box being shipped out [4]
 ....\TU/FandolSong(0)/m/n/12.045 段
 ....\glue(\rightskip) 0.0
 ...\penalty 150
-...\glue(\baselineskip) 10.33862
+...\glue(\baselineskip) 8.33113
 ...\hbox(9.41919+1.98741)x417.11752, glue set 352.6045fil
 ....\TU/FandolSong(0)/m/n/12.045 的
 ....\glue 0.0 plus 0.61353
@@ -2952,15 +2952,15 @@ Completed box being shipped out [4]
 ...\glue 0.0 plus 1.0fil
 ...\glue 0.0
 ...\glue 0.0 plus 0.0001fil
-..\glue(\baselineskip) 7.63202
-..\hbox(14.84546+3.5232)x417.11752
+..\glue(\baselineskip) 8.23427
+..\hbox(14.24321+3.5232)x417.11752
 ...\special{color push  Black}
-...\hbox(14.84546+3.5232)x417.11752
+...\hbox(14.24321+3.5232)x417.11752
 ....\glue 0.0 plus 1.0fil minus 1.0fil
-....\hbox(14.84546+3.5232)x417.11752
-.....\vbox(14.84546+3.5232)x417.11752
+....\hbox(14.24321+3.5232)x417.11752
+.....\vbox(14.24321+3.5232)x417.11752
 ......\rule(0.0+0.0)x417.11752
-......\glue 6.6248
+......\glue 6.02255
 ......\hbox(8.22066+3.5232)x417.11752
 .......\hbox(0.0+0.0)x0.0, glue set - 417.11752fil
 ........\vbox(0.0+0.0)x417.11752
@@ -3095,7 +3095,7 @@ Completed box being shipped out [5]
 ....\special{color pop}
 ..\glue 15.6491
 ..\glue(\lineskip) 0.0
-..\vbox(700.50723+0.0)x417.11752, glue set >20000.0fil
+..\vbox(700.50723+0.0)x417.11752, glue set 15.48946fil
 ...\write-{}
 ...\write2{\@writefile{toc}{\protect \addvspace {12bp}}}
 ...\write2{\pp@pagectr{footnote}{2}{\theabspage }{\thepage }}
@@ -3170,7 +3170,7 @@ Completed box being shipped out [5]
 ...\glue 6.02249
 ...\glue(\parskip) 0.0
 ...\glue(\parskip) 0.0
-...\glue(\baselineskip) 9.94115
+...\glue(\baselineskip) 7.93365
 ...\hbox(9.43123+2.32468)x417.11752, glue set - 0.2467
 ....\hbox(0.0+0.0)x24.09
 ....\TU/FandolSong(0)/m/n/12.045 图
@@ -3246,7 +3246,7 @@ Completed box being shipped out [5]
 ....\TU/FandolSong(0)/m/n/12.045 序
 ....\glue(\rightskip) 0.0
 ...\penalty 10000
-...\glue(\baselineskip) 10.32658
+...\glue(\baselineskip) 8.31909
 ...\hbox(9.43123+2.32468)x417.11752, glue set 0.01607
 ....\TU/FandolSong(0)/m/n/12.045 号
 ....\penalty 10000
@@ -3323,7 +3323,7 @@ Completed box being shipped out [5]
 ....\TU/FandolSong(0)/m/n/12.045 连
 ....\glue(\rightskip) 0.0
 ...\penalty 150
-...\glue(\baselineskip) 10.33862
+...\glue(\baselineskip) 8.33113
 ...\hbox(9.41919+2.13194)x417.11752, glue set 183.01097fil
 ....\TU/FandolSong(0)/m/n/12.045 接
 ....\penalty 10000
@@ -3417,7 +3417,7 @@ Completed box being shipped out [5]
 ...\glue 6.02249
 ...\glue(\parskip) 0.0
 ...\glue(\parskip) 0.0
-...\glue(\baselineskip) 10.44101
+...\glue(\baselineskip) 8.43352
 ...\hbox(9.40715+2.15604)x417.11752, glue set 220.10953fil
 ....\hbox(0.0+0.0)x24.09
 ....\TU/FandolSong(0)/m/n/12.045 插
@@ -3464,9 +3464,9 @@ Completed box being shipped out [5]
 ...\penalty 0
 ...\glue 10.03749
 ...\glue 0.0
-...\vbox(225.50859+0.0)x417.11752
+...\vbox(217.47862+0.0)x417.11752
 ....\special{color push  Black}
-....\vbox(225.50859+0.0)x417.11752
+....\vbox(217.47862+0.0)x417.11752
 .....\hbox(125.13368+0.0)x417.11752, glue set 145.99051fil
 ......\glue(\leftskip) 0.0 plus 1.0fil
 ......\hbox(0.0+0.0)x0.0
@@ -3492,11 +3492,11 @@ Completed box being shipped out [5]
 .....\glue 6.02249
 .....\glue(\parskip) 0.0
 .....\glue(\parskip) 0.0
-.....\hbox(15.45767+6.6248)x417.11752
+.....\hbox(14.05243+6.02255)x417.11752
 ......\hbox(0.0+0.0)x0.0
 ......\glue 0.0
-......\vbox(15.45767+6.6248)x417.11752
-.......\hbox(15.45767+6.6248)x417.11752, glue set 129.68813fil
+......\vbox(14.05243+6.02255)x417.11752
+.......\hbox(14.05243+6.02255)x417.11752, glue set 129.68813fil
 ........\glue(\leftskip) 0.0 plus 1.0fil
 ........\hbox(0.0+0.0)x0.0
 ........\TU/texgyretermes(0)/m/n/12.045 Figure
@@ -3508,7 +3508,7 @@ Completed box being shipped out [5]
 ........\kern -0.0002
 ........\kern 0.0002
 ........\glue 12.045
-........\rule(15.45767+*)x0.0
+........\rule(14.05243+*)x0.0
 ........\penalty 10000
 ........\glue 0.0
 ........\TU/FandolSong(0)/m/n/12.045 图
@@ -3529,7 +3529,7 @@ Completed box being shipped out [5]
 ........\kern -0.00017
 ........\kern 0.00017
 ........\penalty 10000
-........\rule(0.0+6.6248)x0.0
+........\rule(0.0+6.02255)x0.0
 ........\penalty 10000
 ........\glue(\parfillskip) 0.0
 ........\glue(\rightskip) 0.0 plus 1.0fil
@@ -3545,14 +3545,14 @@ Completed box being shipped out [5]
 .....\glue 6.02249
 .....\glue(\parskip) 0.0
 .....\glue(\parskip) 0.0
-.....\hbox(59.62265+6.6248)x417.11752
+.....\hbox(54.20242+6.02255)x417.11752
 ......\hbox(0.0+0.0)x0.0
 ......\glue 21.07874
-......\vbox(59.62265+6.6248)x396.03879
-.......\hbox(15.45767+2.32468)x396.03879, glue set - 0.08005
+......\vbox(54.20242+6.02255)x396.03879
+.......\hbox(14.05243+2.32468)x396.03879, glue set - 0.08005
 ........\glue(\leftskip) 0.0 plus 1.0fil
 ........\hbox(0.0+0.0)x0.0
-........\rule(15.45767+*)x0.0
+........\rule(14.05243+*)x0.0
 ........\penalty 10000
 ........\glue 0.0
 ........\TU/FandolSong(0)/m/n/12.045 若
@@ -3628,7 +3628,7 @@ Completed box being shipped out [5]
 ........\TU/FandolSong(0)/m/n/12.045 标
 ........\glue(\rightskip) 0.0 plus -1.0fil
 .......\penalty 10000
-.......\glue(\baselineskip) 10.35066
+.......\glue(\baselineskip) 8.34317
 .......\hbox(9.40715+2.32468)x396.03879, glue set - 0.12006
 ........\glue(\leftskip) 0.0 plus 1.0fil
 ........\TU/FandolSong(0)/m/n/12.045 点
@@ -3702,8 +3702,8 @@ Completed box being shipped out [5]
 ........\TU/FandolSong(0)/m/n/12.045 注
 ........\glue(\rightskip) 0.0 plus -1.0fil
 .......\penalty 150
-.......\glue(\baselineskip) 10.36272
-.......\hbox(9.3951+6.6248)x396.03879, glue set 27.2454fil
+.......\glue(\baselineskip) 8.35522
+.......\hbox(9.3951+6.02255)x396.03879, glue set 27.2454fil
 ........\glue(\leftskip) 0.0 plus 1.0fil
 ........\TU/FandolSong(0)/m/n/12.045 文
 ........\glue 0.0 plus 0.75479
@@ -3770,7 +3770,7 @@ Completed box being shipped out [5]
 ........\kern -0.18753
 ........\kern 0.18753
 ........\penalty 10000
-........\rule(0.0+6.6248)x0.0
+........\rule(0.0+6.02255)x0.0
 ........\penalty 10000
 ........\glue(\parfillskip) 0.0 plus 2.0fil
 ........\glue(\rightskip) 0.0 plus -1.0fil
@@ -3875,7 +3875,7 @@ Completed box being shipped out [5]
 ...\glue 6.02249
 ...\glue(\parskip) 0.0
 ...\glue(\parskip) 0.0
-...\glue(\baselineskip) 10.1459
+...\glue(\baselineskip) 8.13841
 ...\hbox(9.40715+2.15604)x417.11752, glue set 220.10953fil
 ....\hbox(0.0+0.0)x24.09
 ....\TU/FandolSong(0)/m/n/12.045 表
@@ -3922,19 +3922,19 @@ Completed box being shipped out [5]
 ...\penalty 0
 ...\glue 10.03749
 ...\glue 0.0
-...\vbox(114.73843+0.0)x417.11752
+...\vbox(112.73094+0.0)x417.11752
 ....\special{color push  Black}
-....\vbox(114.73843+0.0)x417.11752
+....\vbox(112.73094+0.0)x417.11752
 .....\write2{\@writefile{lot}{\protect \contentsline {table}{\protect \numberline {2.1}{\ignorespaces 表题置于表的上方}}{\thepage }{}\protected@file@percent }}
 .....\special{color push  Black}
 .....\glue 0.0
 .....\glue(\parskip) 0.0
 .....\glue(\parskip) 0.0
-.....\hbox(15.45767+6.6248)x417.11752
+.....\hbox(14.05243+6.02255)x417.11752
 ......\hbox(0.0+0.0)x0.0
 ......\glue 0.0
-......\vbox(15.45767+6.6248)x417.11752
-.......\hbox(15.45767+6.6248)x417.11752, glue set 132.06099fil
+......\vbox(14.05243+6.02255)x417.11752
+.......\hbox(14.05243+6.02255)x417.11752, glue set 132.06099fil
 ........\glue(\leftskip) 0.0 plus 1.0fil
 ........\hbox(0.0+0.0)x0.0
 ........\TU/texgyretermes(0)/m/n/12.045 Table
@@ -3946,7 +3946,7 @@ Completed box being shipped out [5]
 ........\kern -0.0002
 ........\kern 0.0002
 ........\glue 12.045
-........\rule(15.45767+*)x0.0
+........\rule(14.05243+*)x0.0
 ........\penalty 10000
 ........\glue 0.0
 ........\TU/FandolSong(0)/m/n/12.045 表
@@ -3967,7 +3967,7 @@ Completed box being shipped out [5]
 ........\kern -0.00017
 ........\kern 0.00017
 ........\penalty 10000
-........\rule(0.0+6.6248)x0.0
+........\rule(0.0+6.02255)x0.0
 ........\penalty 10000
 ........\glue(\parfillskip) 0.0
 ........\glue(\rightskip) 0.0 plus 1.0fil
@@ -4227,16 +4227,87 @@ Completed box being shipped out [5]
 ......\glue(\rightskip) 0.0 plus 1.0fil
 .....\glue 0.0
 ....\special{color pop}
+...\penalty 0
+...\penalty 10000
+...\glue 10.03749
+...\glue(\parskip) 0.0
+...\glue(\parskip) 0.0
+...\hbox(9.40715+2.32468)x417.11752, glue set 75.56955fil
+....\hbox(0.0+0.0)x24.09
+....\TU/FandolSong(0)/m/n/12.045 不
+....\glue 0.0 plus 0.61353
+....\TU/FandolSong(0)/m/n/12.045 宜
+....\glue 0.0 plus 0.61353
+....\TU/FandolSong(0)/m/n/12.045 将
+....\glue 0.0 plus 0.61353
+....\TU/FandolSong(0)/m/n/12.045 多
+....\glue 0.0 plus 0.61353
+....\TU/FandolSong(0)/m/n/12.045 个
+....\glue 0.0 plus 0.61353
+....\TU/FandolSong(0)/m/n/12.045 表
+....\glue 0.0 plus 0.61353
+....\TU/FandolSong(0)/m/n/12.045 格
+....\glue 0.0 plus 0.61353
+....\TU/FandolSong(0)/m/n/12.045 连
+....\glue 0.0 plus 0.61353
+....\TU/FandolSong(0)/m/n/12.045 续
+....\glue 0.0 plus 0.61353
+....\TU/FandolSong(0)/m/n/12.045 排
+....\glue 0.0 plus 0.61353
+....\TU/FandolSong(0)/m/n/12.045 版
+....\penalty 10000
+....\TU/FandolSong(0)/m/n/12.045 ，
+....\rule(0.0+0.0)x-8.33514
+....\glue 8.33514 minus 6.0225
+....\glue 0.0 plus 0.61353
+....\TU/FandolSong(0)/m/n/12.045 表
+....\glue 0.0 plus 0.61353
+....\TU/FandolSong(0)/m/n/12.045 格
+....\glue 0.0 plus 0.61353
+....\TU/FandolSong(0)/m/n/12.045 与
+....\glue 0.0 plus 0.61353
+....\TU/FandolSong(0)/m/n/12.045 文
+....\glue 0.0 plus 0.61353
+....\TU/FandolSong(0)/m/n/12.045 字
+....\glue 0.0 plus 0.61353
+....\TU/FandolSong(0)/m/n/12.045 论
+....\glue 0.0 plus 0.61353
+....\TU/FandolSong(0)/m/n/12.045 述
+....\glue 0.0 plus 0.61353
+....\TU/FandolSong(0)/m/n/12.045 段
+....\glue 0.0 plus 0.61353
+....\TU/FandolSong(0)/m/n/12.045 落
+....\glue 0.0 plus 0.61353
+....\TU/FandolSong(0)/m/n/12.045 应
+....\glue 0.0 plus 0.61353
+....\TU/FandolSong(0)/m/n/12.045 穿
+....\glue 0.0 plus 0.61353
+....\TU/FandolSong(0)/m/n/12.045 插
+....\glue 0.0 plus 0.61353
+....\TU/FandolSong(0)/m/n/12.045 排
+....\glue 0.0 plus 0.61353
+....\TU/FandolSong(0)/m/n/12.045 版
+....\penalty 10000
+....\TU/FandolSong(0)/m/n/12.045 。
+....\rule(0.0+0.0)x-7.75697
+....\kern 0.00047
+....\kern -0.00047
+....\kern -0.18753
+....\kern 0.18753
+....\penalty 10000
+....\glue(\parfillskip) 0.0 plus 1.0fil
+....\glue(\rightskip) 0.0
+...\glue 0.0 plus 1.0fil
 ...\glue 0.0
 ...\glue 0.0 plus 0.0001fil
-..\glue(\baselineskip) 7.63202
-..\hbox(14.84546+3.5232)x417.11752
+..\glue(\baselineskip) 8.23427
+..\hbox(14.24321+3.5232)x417.11752
 ...\special{color push  Black}
-...\hbox(14.84546+3.5232)x417.11752
-....\hbox(14.84546+3.5232)x417.11752
-.....\vbox(14.84546+3.5232)x417.11752
+...\hbox(14.24321+3.5232)x417.11752
+....\hbox(14.24321+3.5232)x417.11752
+.....\vbox(14.24321+3.5232)x417.11752
 ......\rule(0.0+0.0)x417.11752
-......\glue 6.6248
+......\glue 6.02255
 ......\hbox(8.22066+3.5232)x417.11752
 .......\hbox(0.0+0.0)x0.0, glue set - 417.11752fil
 ........\vbox(0.0+0.0)x417.11752
@@ -4270,6 +4341,26 @@ Completed box being shipped out [5]
 ..........\glue(\rightskip) 0.0
 ....\glue 0.0 plus 1.0fil minus 1.0fil
 ...\special{color pop}
+LaTeX Font Info:    Font shape `TU/XITSMath-Regular(1)/m/n' will be
+(Font)              scaled to size 9.03375pt on input line ....
+LaTeX Font Info:    Font shape `TU/XITSMath-Regular(1)/m/n' will be
+(Font)              scaled to size 7.227pt on input line ....
+LaTeX Font Info:    Font shape `TU/XITSMath-Regular(2)/m/n' will be
+(Font)              scaled to size 12.0461pt on input line ....
+LaTeX Font Info:    Font shape `TU/XITSMath-Regular(2)/m/n' will be
+(Font)              scaled to size 9.03458pt on input line ....
+LaTeX Font Info:    Font shape `TU/XITSMath-Regular(2)/m/n' will be
+(Font)              scaled to size 7.22766pt on input line ....
+LaTeX Font Info:    Font shape `TU/XITSMath-Regular(3)/m/n' will be
+(Font)              scaled to size 12.0437pt on input line ....
+LaTeX Font Info:    Font shape `TU/XITSMath-Regular(3)/m/n' will be
+(Font)              scaled to size 9.03278pt on input line ....
+LaTeX Font Info:    Font shape `TU/XITSMath-Regular(3)/m/n' will be
+(Font)              scaled to size 7.22623pt on input line ....
+LaTeX Font Info:    Font shape `TU/STIXTwoMath-Regular(0)/m/n' will be
+(Font)              scaled to size 8.59444pt on input line ....
+LaTeX Font Info:    Font shape `TU/STIXTwoMath-Regular(0)/m/n' will be
+(Font)              scaled to size 6.87555pt on input line ....
 Completed box being shipped out [6]
 \vbox(722.98453+3.5232)x435.04271
 .\glue -29.59128
@@ -4345,63 +4436,172 @@ Completed box being shipped out [6]
 ....\special{color pop}
 ..\glue 15.6491
 ..\glue(\lineskip) 0.0
-..\vbox(700.50723+0.0)x417.11752, glue set 686.10927fil
-...\glue(\topskip) 2.59285
-...\hbox(9.40715+2.32468)x417.11752, glue set 75.56955fil
+..\vbox(700.50723+0.0)x417.11752, glue set 607.82516fil
+...\write-{}
+...\glue(\topskip) 1.15147
+...\hbox(10.84853+2.52943)x417.11752, glue set 329.65482fil
+....\hbox(9.96321+0.21077)x45.30524
+.....\TU/texgyreheros(0)/m/n/14.05249 2.1.3
+.....\kern -0.0002
+.....\kern 0.0002
+.....\glue 14.05249
+....\TU/FandolHei(0)/m/n/14.05249 表
+....\glue 0.0 plus 0.87584
+....\TU/FandolHei(0)/m/n/14.05249 达
+....\glue 0.0 plus 0.87584
+....\TU/FandolHei(0)/m/n/14.05249 式
+....\kern -0.00017
+....\kern 0.00017
+....\penalty 10000
+....\glue(\parfillskip) 0.0 plus 1.0fil
+....\glue(\rightskip) 0.0
+...\write2{\@writefile{toc}{\protect \contentsline {subsection}{\protect \numberline {2.1.3}表达式}{\thepage }{}\protected@file@percent }}
+...\penalty 10000
+...\glue 6.02249
+...\glue(\parskip) 0.0
+...\glue(\parskip) 0.0
+...\glue(\baselineskip) 8.11433
+...\hbox(9.43123+2.21626)x417.11752, glue set 135.79454fil
 ....\hbox(0.0+0.0)x24.09
-....\TU/FandolSong(0)/m/n/12.045 不
-....\glue 0.0 plus 0.61353
-....\TU/FandolSong(0)/m/n/12.045 宜
-....\glue 0.0 plus 0.61353
-....\TU/FandolSong(0)/m/n/12.045 将
-....\glue 0.0 plus 0.61353
-....\TU/FandolSong(0)/m/n/12.045 多
-....\glue 0.0 plus 0.61353
-....\TU/FandolSong(0)/m/n/12.045 个
-....\glue 0.0 plus 0.61353
 ....\TU/FandolSong(0)/m/n/12.045 表
 ....\glue 0.0 plus 0.61353
-....\TU/FandolSong(0)/m/n/12.045 格
+....\TU/FandolSong(0)/m/n/12.045 达
+....\glue 0.0 plus 0.61353
+....\TU/FandolSong(0)/m/n/12.045 式
+....\glue 0.0 plus 0.61353
+....\TU/FandolSong(0)/m/n/12.045 主
+....\glue 0.0 plus 0.61353
+....\TU/FandolSong(0)/m/n/12.045 要
+....\glue 0.0 plus 0.61353
+....\TU/FandolSong(0)/m/n/12.045 是
+....\glue 0.0 plus 0.61353
+....\TU/FandolSong(0)/m/n/12.045 指
+....\glue 0.0 plus 0.61353
+....\TU/FandolSong(0)/m/n/12.045 分
+....\glue 0.0 plus 0.61353
+....\TU/FandolSong(0)/m/n/12.045 章
 ....\glue 0.0 plus 0.61353
 ....\TU/FandolSong(0)/m/n/12.045 连
 ....\glue 0.0 plus 0.61353
 ....\TU/FandolSong(0)/m/n/12.045 续
 ....\glue 0.0 plus 0.61353
-....\TU/FandolSong(0)/m/n/12.045 排
+....\TU/FandolSong(0)/m/n/12.045 编
 ....\glue 0.0 plus 0.61353
-....\TU/FandolSong(0)/m/n/12.045 版
+....\TU/FandolSong(0)/m/n/12.045 有
+....\glue 0.0 plus 0.61353
+....\TU/FandolSong(0)/m/n/12.045 序
+....\glue 0.0 plus 0.61353
+....\TU/FandolSong(0)/m/n/12.045 号
+....\glue 0.0 plus 0.61353
+....\TU/FandolSong(0)/m/n/12.045 的
+....\glue 0.0 plus 0.61353
+....\TU/FandolSong(0)/m/n/12.045 数
+....\glue 0.0 plus 0.61353
+....\TU/FandolSong(0)/m/n/12.045 字
+....\glue 0.0 plus 0.61353
+....\TU/FandolSong(0)/m/n/12.045 表
+....\glue 0.0 plus 0.61353
+....\TU/FandolSong(0)/m/n/12.045 达
+....\glue 0.0 plus 0.61353
+....\TU/FandolSong(0)/m/n/12.045 式
+....\penalty 10000
+....\TU/FandolSong(0)/m/n/12.045 。
+....\rule(0.0+0.0)x-7.75697
+....\kern 0.00047
+....\kern -0.00047
+....\kern -0.18753
+....\kern 0.18753
+....\penalty 10000
+....\glue(\parfillskip) 0.0 plus 1.0fil
+....\glue(\rightskip) 0.0
+...\penalty 10000
+...\glue(\abovedisplayskip) 6.02249 plus 3.01125 minus 3.01125
+...\glue(\baselineskip) 9.71631
+...\hbox(8.14243+3.01152)x252.87306, shifted 164.24446
+....\hbox(5.5407+3.01152)x88.62862, display
+.....\hbox(0.0+0.0)x0.0
+.....\TU/XITSMath-Regular(1)/m/n/12.045 glyph#2523
+.....\hbox(6.10681+0.0)x5.01688, shifted 3.01152
+......\TU/XITSMath-Regular(1)/m/n/9.03375 glyph#50
+.....\glue(\thickmuskip) 3.3461 plus 3.3461
+.....\TU/XITSMath-Regular(1)/m/n/12.045 glyph#62
+.....\glue(\thickmuskip) 3.3461 plus 3.3461
+.....\TU/XITSMath-Regular(1)/m/n/12.045 glyph#2521
+.....\hbox(6.10681+0.0)x9.53375, shifted 3.01152
+......\TU/XITSMath-Regular(1)/m/n/9.03375 glyph#50
+......\TU/XITSMath-Regular(1)/m/n/9.03375 glyph#50
+.....\glue(\medmuskip) 2.67688 plus 1.33844 minus 2.67688
+.....\TU/XITSMath-Regular(1)/m/n/12.045 glyph#1155
+.....\glue(\medmuskip) 2.67688 plus 1.33844 minus 2.67688
+.....\TU/XITSMath-Regular(1)/m/n/12.045 glyph#2521
+.....\hbox(6.10681+0.0)x9.53375, shifted 3.01152
+......\TU/XITSMath-Regular(1)/m/n/9.03375 glyph#50
+......\TU/XITSMath-Regular(1)/m/n/9.03375 glyph#51
+.....\TU/XITSMath-Regular(1)/m/n/12.045 glyph#2521
+.....\hbox(6.10681+0.0)x9.53375, shifted 3.01152
+......\TU/XITSMath-Regular(1)/m/n/9.03375 glyph#51
+......\TU/XITSMath-Regular(1)/m/n/9.03375 glyph#50
+....\kern141.16623
+....\hbox(8.14243+2.13194)x23.07822, display
+.....\hbox(8.14243+2.13194)x23.07822
+......\TU/texgyretermes(0)/m/n/12.045 (2.1
+......\kern -0.0002
+......\kern 0.0002
+......\TU/texgyretermes(0)/m/n/12.045 )
+......\kern -0.0002
+......\kern 0.0002
+.....\write2{\newlabel{eq:example}{{2.1}{\thepage }{}{equation.2.1}{}}}
+...\penalty 0
+...\glue(\belowdisplayskip) 6.02249 plus 3.01125 minus 3.01125
+...\glue(\baselineskip) 7.69247
+...\hbox(9.371+2.32468)x417.11752, glue set 147.83954fil
+....\TU/FandolSong(0)/m/n/12.045 表
+....\glue 0.0 plus 0.61353
+....\TU/FandolSong(0)/m/n/12.045 达
+....\glue 0.0 plus 0.61353
+....\TU/FandolSong(0)/m/n/12.045 式
+....\glue 0.0 plus 0.61353
+....\TU/FandolSong(0)/m/n/12.045 的
+....\glue 0.0 plus 0.61353
+....\TU/FandolSong(0)/m/n/12.045 行
+....\glue 0.0 plus 0.61353
+....\TU/FandolSong(0)/m/n/12.045 距
+....\glue 0.0 plus 0.61353
+....\TU/FandolSong(0)/m/n/12.045 根
+....\glue 0.0 plus 0.61353
+....\TU/FandolSong(0)/m/n/12.045 据
+....\glue 0.0 plus 0.61353
+....\TU/FandolSong(0)/m/n/12.045 需
+....\glue 0.0 plus 0.61353
+....\TU/FandolSong(0)/m/n/12.045 要
+....\glue 0.0 plus 0.61353
+....\TU/FandolSong(0)/m/n/12.045 采
+....\glue 0.0 plus 0.61353
+....\TU/FandolSong(0)/m/n/12.045 用
 ....\penalty 10000
 ....\TU/FandolSong(0)/m/n/12.045 ，
 ....\rule(0.0+0.0)x-8.33514
 ....\glue 8.33514 minus 6.0225
 ....\glue 0.0 plus 0.61353
-....\TU/FandolSong(0)/m/n/12.045 表
+....\TU/FandolSong(0)/m/n/12.045 段
 ....\glue 0.0 plus 0.61353
-....\TU/FandolSong(0)/m/n/12.045 格
-....\glue 0.0 plus 0.61353
-....\TU/FandolSong(0)/m/n/12.045 与
-....\glue 0.0 plus 0.61353
-....\TU/FandolSong(0)/m/n/12.045 文
-....\glue 0.0 plus 0.61353
-....\TU/FandolSong(0)/m/n/12.045 字
-....\glue 0.0 plus 0.61353
-....\TU/FandolSong(0)/m/n/12.045 论
-....\glue 0.0 plus 0.61353
-....\TU/FandolSong(0)/m/n/12.045 述
+....\TU/FandolSong(0)/m/n/12.045 前
+....\glue 3.01125 plus 1.50562 minus 1.00374
+....\TU/texgyretermes(0)/m/n/12.045 6
+....\glue 3.01125 plus 1.50562 minus 1.00374
+....\TU/FandolSong(0)/m/n/12.045 磅
+....\penalty 10000
+....\TU/FandolSong(0)/m/n/12.045 、
+....\rule(0.0+0.0)x-7.85333
+....\glue 7.85333 minus 6.02249
 ....\glue 0.0 plus 0.61353
 ....\TU/FandolSong(0)/m/n/12.045 段
 ....\glue 0.0 plus 0.61353
-....\TU/FandolSong(0)/m/n/12.045 落
-....\glue 0.0 plus 0.61353
-....\TU/FandolSong(0)/m/n/12.045 应
-....\glue 0.0 plus 0.61353
-....\TU/FandolSong(0)/m/n/12.045 穿
-....\glue 0.0 plus 0.61353
-....\TU/FandolSong(0)/m/n/12.045 插
-....\glue 0.0 plus 0.61353
-....\TU/FandolSong(0)/m/n/12.045 排
-....\glue 0.0 plus 0.61353
-....\TU/FandolSong(0)/m/n/12.045 版
+....\TU/FandolSong(0)/m/n/12.045 后
+....\glue 3.01125 plus 1.50562 minus 1.00374
+....\TU/texgyretermes(0)/m/n/12.045 6
+....\glue 3.01125 plus 1.50562 minus 1.00374
+....\TU/FandolSong(0)/m/n/12.045 磅
 ....\penalty 10000
 ....\TU/FandolSong(0)/m/n/12.045 。
 ....\rule(0.0+0.0)x-7.75697
@@ -4415,15 +4615,15 @@ Completed box being shipped out [6]
 ...\glue 0.0 plus 1.0fil
 ...\glue 0.0
 ...\glue 0.0 plus 0.0001fil
-..\glue(\baselineskip) 7.63202
-..\hbox(14.84546+3.5232)x417.11752
+..\glue(\baselineskip) 8.23427
+..\hbox(14.24321+3.5232)x417.11752
 ...\special{color push  Black}
-...\hbox(14.84546+3.5232)x417.11752
+...\hbox(14.24321+3.5232)x417.11752
 ....\glue 0.0 plus 1.0fil minus 1.0fil
-....\hbox(14.84546+3.5232)x417.11752
-.....\vbox(14.84546+3.5232)x417.11752
+....\hbox(14.24321+3.5232)x417.11752
+.....\vbox(14.24321+3.5232)x417.11752
 ......\rule(0.0+0.0)x417.11752
-......\glue 6.6248
+......\glue 6.02255
 ......\hbox(8.22066+3.5232)x417.11752
 .......\hbox(0.0+0.0)x0.0, glue set - 417.11752fil
 ........\vbox(0.0+0.0)x417.11752
@@ -4456,26 +4656,7 @@ Completed box being shipped out [6]
 ..........\glue(\parfillskip) 0.0
 ..........\glue(\rightskip) 0.0
 ...\special{color pop}
-LaTeX Font Info:    Font shape `TU/XITSMath-Regular(1)/m/n' will be
-(Font)              scaled to size 9.03375pt on input line ....
-LaTeX Font Info:    Font shape `TU/XITSMath-Regular(1)/m/n' will be
-(Font)              scaled to size 7.227pt on input line ....
-LaTeX Font Info:    Font shape `TU/XITSMath-Regular(2)/m/n' will be
-(Font)              scaled to size 12.0461pt on input line ....
-LaTeX Font Info:    Font shape `TU/XITSMath-Regular(2)/m/n' will be
-(Font)              scaled to size 9.03458pt on input line ....
-LaTeX Font Info:    Font shape `TU/XITSMath-Regular(2)/m/n' will be
-(Font)              scaled to size 7.22766pt on input line ....
-LaTeX Font Info:    Font shape `TU/XITSMath-Regular(3)/m/n' will be
-(Font)              scaled to size 12.0437pt on input line ....
-LaTeX Font Info:    Font shape `TU/XITSMath-Regular(3)/m/n' will be
-(Font)              scaled to size 9.03278pt on input line ....
-LaTeX Font Info:    Font shape `TU/XITSMath-Regular(3)/m/n' will be
-(Font)              scaled to size 7.22623pt on input line ....
-LaTeX Font Info:    Font shape `TU/STIXTwoMath-Regular(0)/m/n' will be
-(Font)              scaled to size 8.59444pt on input line ....
-LaTeX Font Info:    Font shape `TU/STIXTwoMath-Regular(0)/m/n' will be
-(Font)              scaled to size 6.87555pt on input line ....
+Chapter 3
 Completed box being shipped out [7]
 \vbox(722.98453+3.5232)x435.04271
 .\glue -29.59128
@@ -4551,193 +4732,68 @@ Completed box being shipped out [7]
 ....\special{color pop}
 ..\glue 15.6491
 ..\glue(\lineskip) 0.0
-..\vbox(700.50723+0.0)x417.11752, glue set 601.80333fil
+..\vbox(700.50723+0.0)x417.11752, glue set 630.89862fil
 ...\write-{}
-...\glue(\topskip) 1.15147
-...\hbox(10.84853+2.52943)x417.11752, glue set 329.65482fil
-....\hbox(9.96321+0.21077)x45.30524
-.....\TU/texgyreheros(0)/m/n/14.05249 2.1.3
-.....\kern -0.0002
-.....\kern 0.0002
-.....\glue 14.05249
-....\TU/FandolHei(0)/m/n/14.05249 表
-....\glue 0.0 plus 0.87584
-....\TU/FandolHei(0)/m/n/14.05249 达
-....\glue 0.0 plus 0.87584
-....\TU/FandolHei(0)/m/n/14.05249 式
+...\write2{\@writefile{toc}{\protect \addvspace {12bp}}}
+...\write2{\pp@pagectr{footnote}{3}{\theabspage }{\thepage }}
+...\write2{\@writefile{toc}{\protect \contentsline {chapter}{\protect \numberline {Chapter 3}引用}{\thepage }{}\protected@file@percent }}
+...\glue(\topskip) 12.0
+...\rule(0.0+0.0)x*
+...\penalty 10000
+...\glue 7.02625
+...\glue 0.0
+...\glue(\parskip) 0.0
+...\glue(\parskip) 0.0
+...\glue(\baselineskip) 17.41104
+...\hbox(12.02895+3.50107)x417.11752, glue set 149.36964fil
+....\glue(\leftskip) 0.0 plus 1.0fil
+....\TU/texgyreheros(0)/m/n/16.06 Chapter
+....\glue 4.46468 plus 2.23233 minus 1.48822
+....\TU/texgyreheros(0)/m/n/16.06 3
+....\kern -0.0002
+....\kern 0.0002
+....\glue 16.06
+....\TU/FandolHei(0)/m/n/16.06 引
+....\glue 0.0 plus 1.37729
+....\TU/FandolHei(0)/m/n/16.06 用
 ....\kern -0.00017
 ....\kern 0.00017
 ....\penalty 10000
-....\glue(\parfillskip) 0.0 plus 1.0fil
-....\glue(\rightskip) 0.0
-...\write2{\@writefile{toc}{\protect \contentsline {subsection}{\protect \numberline {2.1.3}表达式}{\thepage }{}\protected@file@percent }}
+....\glue(\parfillskip) 0.0
+....\glue(\rightskip) 0.0 plus 1.0fil
 ...\penalty 10000
-...\glue 6.02249
+...\kern 1.0
 ...\glue(\parskip) 0.0
 ...\glue(\parskip) 0.0
-...\glue(\baselineskip) 10.12183
-...\hbox(9.43123+2.21626)x417.11752, glue set 135.79454fil
+...\glue(\baselineskip) 5.64868
+...\hbox(10.92525+0.0)x417.11752, glue set 380.99417fil
 ....\hbox(0.0+0.0)x24.09
-....\TU/FandolSong(0)/m/n/12.045 表
-....\glue 0.0 plus 0.61353
-....\TU/FandolSong(0)/m/n/12.045 达
-....\glue 0.0 plus 0.61353
-....\TU/FandolSong(0)/m/n/12.045 式
-....\glue 0.0 plus 0.61353
-....\TU/FandolSong(0)/m/n/12.045 主
-....\glue 0.0 plus 0.61353
-....\TU/FandolSong(0)/m/n/12.045 要
-....\glue 0.0 plus 0.61353
-....\TU/FandolSong(0)/m/n/12.045 是
-....\glue 0.0 plus 0.61353
-....\TU/FandolSong(0)/m/n/12.045 指
-....\glue 0.0 plus 0.61353
-....\TU/FandolSong(0)/m/n/12.045 分
-....\glue 0.0 plus 0.61353
-....\TU/FandolSong(0)/m/n/12.045 章
-....\glue 0.0 plus 0.61353
-....\TU/FandolSong(0)/m/n/12.045 连
-....\glue 0.0 plus 0.61353
-....\TU/FandolSong(0)/m/n/12.045 续
-....\glue 0.0 plus 0.61353
-....\TU/FandolSong(0)/m/n/12.045 编
-....\glue 0.0 plus 0.61353
-....\TU/FandolSong(0)/m/n/12.045 有
-....\glue 0.0 plus 0.61353
-....\TU/FandolSong(0)/m/n/12.045 序
-....\glue 0.0 plus 0.61353
-....\TU/FandolSong(0)/m/n/12.045 号
-....\glue 0.0 plus 0.61353
-....\TU/FandolSong(0)/m/n/12.045 的
-....\glue 0.0 plus 0.61353
-....\TU/FandolSong(0)/m/n/12.045 数
-....\glue 0.0 plus 0.61353
-....\TU/FandolSong(0)/m/n/12.045 字
-....\glue 0.0 plus 0.61353
-....\TU/FandolSong(0)/m/n/12.045 表
-....\glue 0.0 plus 0.61353
-....\TU/FandolSong(0)/m/n/12.045 达
-....\glue 0.0 plus 0.61353
-....\TU/FandolSong(0)/m/n/12.045 式
-....\penalty 10000
-....\TU/FandolSong(0)/m/n/12.045 。
-....\rule(0.0+0.0)x-7.75697
-....\kern 0.00047
-....\kern -0.00047
-....\kern -0.18753
-....\kern 0.18753
-....\penalty 10000
-....\glue(\parfillskip) 0.0 plus 1.0fil
-....\glue(\rightskip) 0.0
-...\penalty 10000
-...\glue(\abovedisplayskip) 6.02249 plus 3.01125 minus 3.01125
-...\glue(\baselineskip) 11.7238
-...\hbox(8.14243+3.01152)x252.87306, shifted 164.24446
-....\hbox(5.5407+3.01152)x88.62862, display
-.....\hbox(0.0+0.0)x0.0
-.....\TU/XITSMath-Regular(1)/m/n/12.045 glyph#2523
-.....\hbox(6.10681+0.0)x5.01688, shifted 3.01152
-......\TU/XITSMath-Regular(1)/m/n/9.03375 glyph#50
-.....\glue(\thickmuskip) 3.3461 plus 3.3461
-.....\TU/XITSMath-Regular(1)/m/n/12.045 glyph#62
-.....\glue(\thickmuskip) 3.3461 plus 3.3461
-.....\TU/XITSMath-Regular(1)/m/n/12.045 glyph#2521
-.....\hbox(6.10681+0.0)x9.53375, shifted 3.01152
-......\TU/XITSMath-Regular(1)/m/n/9.03375 glyph#50
-......\TU/XITSMath-Regular(1)/m/n/9.03375 glyph#50
-.....\glue(\medmuskip) 2.67688 plus 1.33844 minus 2.67688
-.....\TU/XITSMath-Regular(1)/m/n/12.045 glyph#1155
-.....\glue(\medmuskip) 2.67688 plus 1.33844 minus 2.67688
-.....\TU/XITSMath-Regular(1)/m/n/12.045 glyph#2521
-.....\hbox(6.10681+0.0)x9.53375, shifted 3.01152
-......\TU/XITSMath-Regular(1)/m/n/9.03375 glyph#50
-......\TU/XITSMath-Regular(1)/m/n/9.03375 glyph#51
-.....\TU/XITSMath-Regular(1)/m/n/12.045 glyph#2521
-.....\hbox(6.10681+0.0)x9.53375, shifted 3.01152
-......\TU/XITSMath-Regular(1)/m/n/9.03375 glyph#51
-......\TU/XITSMath-Regular(1)/m/n/9.03375 glyph#50
-....\kern141.16623
-....\hbox(8.14243+2.13194)x23.07822, display
-.....\hbox(8.14243+2.13194)x23.07822
-......\TU/texgyretermes(0)/m/n/12.045 (2.1
+....\mathon
+....\hbox(6.10681+1.40926)x11.03336, shifted -4.81844
+.....\TU/texgyretermes(0)/m/n/9.03375 [
+.....\hbox(6.10681+0.0)x4.51688
+......\TU/texgyretermes(0)/m/n/9.03375 1
 ......\kern -0.0002
 ......\kern 0.0002
-......\TU/texgyretermes(0)/m/n/12.045 )
-......\kern -0.0002
-......\kern 0.0002
-.....\write2{\newlabel{eq:example}{{2.1}{\thepage }{}{equation.2.1}{}}}
-...\penalty 0
-...\glue(\belowdisplayskip) 6.02249 plus 3.01125 minus 3.01125
-...\glue(\baselineskip) 9.69997
-...\hbox(9.371+2.32468)x417.11752, glue set 147.83954fil
-....\TU/FandolSong(0)/m/n/12.045 表
-....\glue 0.0 plus 0.61353
-....\TU/FandolSong(0)/m/n/12.045 达
-....\glue 0.0 plus 0.61353
-....\TU/FandolSong(0)/m/n/12.045 式
-....\glue 0.0 plus 0.61353
-....\TU/FandolSong(0)/m/n/12.045 的
-....\glue 0.0 plus 0.61353
-....\TU/FandolSong(0)/m/n/12.045 行
-....\glue 0.0 plus 0.61353
-....\TU/FandolSong(0)/m/n/12.045 距
-....\glue 0.0 plus 0.61353
-....\TU/FandolSong(0)/m/n/12.045 根
-....\glue 0.0 plus 0.61353
-....\TU/FandolSong(0)/m/n/12.045 据
-....\glue 0.0 plus 0.61353
-....\TU/FandolSong(0)/m/n/12.045 需
-....\glue 0.0 plus 0.61353
-....\TU/FandolSong(0)/m/n/12.045 要
-....\glue 0.0 plus 0.61353
-....\TU/FandolSong(0)/m/n/12.045 采
-....\glue 0.0 plus 0.61353
-....\TU/FandolSong(0)/m/n/12.045 用
-....\penalty 10000
-....\TU/FandolSong(0)/m/n/12.045 ，
-....\rule(0.0+0.0)x-8.33514
-....\glue 8.33514 minus 6.0225
-....\glue 0.0 plus 0.61353
-....\TU/FandolSong(0)/m/n/12.045 段
-....\glue 0.0 plus 0.61353
-....\TU/FandolSong(0)/m/n/12.045 前
-....\glue 3.01125 plus 1.50562 minus 1.00374
-....\TU/texgyretermes(0)/m/n/12.045 6
-....\glue 3.01125 plus 1.50562 minus 1.00374
-....\TU/FandolSong(0)/m/n/12.045 磅
-....\penalty 10000
-....\TU/FandolSong(0)/m/n/12.045 、
-....\rule(0.0+0.0)x-7.85333
-....\glue 7.85333 minus 6.02249
-....\glue 0.0 plus 0.61353
-....\TU/FandolSong(0)/m/n/12.045 段
-....\glue 0.0 plus 0.61353
-....\TU/FandolSong(0)/m/n/12.045 后
-....\glue 3.01125 plus 1.50562 minus 1.00374
-....\TU/texgyretermes(0)/m/n/12.045 6
-....\glue 3.01125 plus 1.50562 minus 1.00374
-....\TU/FandolSong(0)/m/n/12.045 磅
-....\penalty 10000
-....\TU/FandolSong(0)/m/n/12.045 。
-....\rule(0.0+0.0)x-7.75697
-....\kern 0.00047
-....\kern -0.00047
-....\kern -0.18753
-....\kern 0.18753
+.....\TU/texgyretermes(0)/m/n/9.03375 ]
+.....\kern -0.0002
+.....\kern 0.0002
+....\mathoff
+....\kern 1.0
 ....\penalty 10000
 ....\glue(\parfillskip) 0.0 plus 1.0fil
 ....\glue(\rightskip) 0.0
 ...\glue 0.0 plus 1.0fil
 ...\glue 0.0
 ...\glue 0.0 plus 0.0001fil
-..\glue(\baselineskip) 7.63202
-..\hbox(14.84546+3.5232)x417.11752
+..\glue(\baselineskip) 8.23427
+..\hbox(14.24321+3.5232)x417.11752
 ...\special{color push  Black}
-...\hbox(14.84546+3.5232)x417.11752
-....\hbox(14.84546+3.5232)x417.11752
-.....\vbox(14.84546+3.5232)x417.11752
+...\hbox(14.24321+3.5232)x417.11752
+....\hbox(14.24321+3.5232)x417.11752
+.....\vbox(14.24321+3.5232)x417.11752
 ......\rule(0.0+0.0)x417.11752
-......\glue 6.6248
+......\glue 6.02255
 ......\hbox(8.22066+3.5232)x417.11752
 .......\hbox(0.0+0.0)x0.0, glue set - 417.11752fil
 ........\vbox(0.0+0.0)x417.11752
@@ -4771,7 +4827,6 @@ Completed box being shipped out [7]
 ..........\glue(\rightskip) 0.0
 ....\glue 0.0 plus 1.0fil minus 1.0fil
 ...\special{color pop}
-Chapter 3
 Completed box being shipped out [8]
 \vbox(722.98453+3.5232)x435.04271
 .\glue -29.59128
@@ -4847,11 +4902,10 @@ Completed box being shipped out [8]
 ....\special{color pop}
 ..\glue 15.6491
 ..\glue(\lineskip) 0.0
-..\vbox(700.50723+0.0)x417.11752, glue set 628.89134fil
+..\vbox(700.50723+0.0)x417.11752, glue set 586.44757fil
 ...\write-{}
 ...\write2{\@writefile{toc}{\protect \addvspace {12bp}}}
-...\write2{\pp@pagectr{footnote}{3}{\theabspage }{\thepage }}
-...\write2{\@writefile{toc}{\protect \contentsline {chapter}{\protect \numberline {Chapter 3}引用}{\thepage }{}\protected@file@percent }}
+...\write2{\@writefile{toc}{\protect \contentsline {chapter}{Bibliography}{\thepage }{}\protected@file@percent }}
 ...\glue(\topskip) 12.0
 ...\rule(0.0+0.0)x*
 ...\penalty 10000
@@ -4859,57 +4913,117 @@ Completed box being shipped out [8]
 ...\glue 0.0
 ...\glue(\parskip) 0.0
 ...\glue(\parskip) 0.0
-...\glue(\baselineskip) 17.41104
-...\hbox(12.02895+3.50107)x417.11752, glue set 149.36964fil
+...\glue(\baselineskip) 19.95255
+...\hbox(13.1712+3.93869)x417.11752, glue set 159.08095fil
 ....\glue(\leftskip) 0.0 plus 1.0fil
-....\TU/texgyreheros(0)/m/n/16.06 Chapter
-....\glue 4.46468 plus 2.23233 minus 1.48822
-....\TU/texgyreheros(0)/m/n/16.06 3
+....\TU/texgyreheros(0)/m/n/18.06749 Bibliography
 ....\kern -0.0002
 ....\kern 0.0002
-....\glue 16.06
-....\TU/FandolHei(0)/m/n/16.06 引
-....\glue 0.0 plus 1.37729
-....\TU/FandolHei(0)/m/n/16.06 用
-....\kern -0.00017
-....\kern 0.00017
 ....\penalty 10000
 ....\glue(\parfillskip) 0.0
 ....\glue(\rightskip) 0.0 plus 1.0fil
 ...\penalty 10000
-...\kern 1.0
+...\glue 19.07124
 ...\glue(\parskip) 0.0
 ...\glue(\parskip) 0.0
-...\glue(\baselineskip) 7.65617
-...\hbox(10.92525+0.0)x417.11752, glue set 380.99417fil
-....\hbox(0.0+0.0)x24.09
-....\mathon
-....\hbox(6.10681+1.40926)x11.03336, shifted -4.81844
-.....\TU/texgyretermes(0)/m/n/9.03375 [
-.....\hbox(6.10681+0.0)x4.51688
-......\TU/texgyretermes(0)/m/n/9.03375 1
+...\glue(\baselineskip) 7.90958
+...\hbox(8.22673+2.71011)x387.00504, glue set - 0.07979, shifted 30.11249
+....\hbox(8.14243+1.879)x0.0
+.....\glue 0.0
+.....\glue -30.11249
+.....\glue 0.0
+.....\hbox(8.14243+1.879)x30.11249, glue set 16.06802fill
+......\special{color push  Black}
+......\glue 0.0 plus 1.0fil
+......\glue 0.0 plus 1.0fil
+......\TU/texgyretermes(0)/m/n/12.045 [1]
 ......\kern -0.0002
 ......\kern 0.0002
-.....\TU/texgyretermes(0)/m/n/9.03375 ]
+......\glue 0.0 plus 1.0fill
+......\special{color pop}
+.....\glue 0.0
+....\penalty 0
+....\TU/texgyretermes(0)/m/n/12.045 KNUTH
+....\kern -0.0002
+....\kern 0.0002
+....\penalty 10000
+....\glue 3.01125 plus 1.50562 minus 1.00374
+....\TU/texgyretermes(0)/m/n/12.045 D
+....\kern -0.0002
+....\kern 0.0002
+....\penalty 10000
+....\glue 3.01125 plus 1.50562 minus 1.00374
+....\TU/texgyretermes(0)/m/n/12.045 E.
+....\glue 3.01125 plus 1.50562 minus 1.00374
+....\glue 1.32495 plus 3.97487 minus 0.84323
+....\TU/texgyretermes(0)/m/n/12.045 Computers
+....\glue 3.01125 plus 1.50562 minus 1.00374
+....\TU/texgyretermes(0)/m/n/12.045 and
+....\glue 3.01125 plus 1.50562 minus 1.00374
+....\TU/texgyretermes(0)/m/n/12.045 typesetting:
+....\glue 4.01498 plus 3.01123 minus 0.50186
+....\TU/texgyretermes(0)/m/n/12.045 volume
+....\kern -0.0002
+....\kern 0.0002
+....\penalty 10000
+....\glue 3.01125 plus 1.50562 minus 1.00374
+....\TU/texgyretermes(0)/m/n/12.045 A
+....\kern -0.0002
+....\kern 0.0002
+....\glue 12.045
+....\TU/texgyretermes(0)/m/n/12.045 The
+....\glue 3.01125 plus 1.50562 minus 1.00374
+....\TU/texgyretermes(0)/m/n/12.045 T
+....\kern -0.0002
+....\kern 0.0002
+....\kern -2.00792
+....\hbox(7.97379+0.0)x7.3595, shifted 2.71011
+.....\TU/texgyretermes(0)/m/n/12.045 E
 .....\kern -0.0002
 .....\kern 0.0002
-....\mathoff
-....\kern 1.0
+....\kern -1.50562
+....\TU/texgyretermes(0)/m/n/12.045 X
+....\kern -0.0002
+....\kern 0.0002
+....\TU/texgyretermes(0)/m/n/12.045 book
+....\kern -0.0002
+....\kern 0.0002
+....\penalty 0
+....\TU/texgyretermes(0)/m/n/12.045 [M].
+....\glue 3.01125 plus 1.50562 minus 1.00374
+....\glue 1.32495 plus 3.97487 minus 0.84323
+....\TU/texgyretermes(0)/m/n/12.045 Read-
+....\glue(\rightskip) 0.0
+...\penalty 14100
+...\glue(\baselineskip) 9.1261
+...\hbox(8.23878+2.6258)x387.00504, glue set 199.12717fil, shifted 30.11249
+....\TU/texgyretermes(0)/m/n/12.045 ing,
+....\glue 3.01125 plus 1.88202 minus 0.80298
+....\TU/texgyretermes(0)/m/n/12.045 MA,
+....\glue 3.01125 plus 1.50562 minus 1.00374
+....\TU/texgyretermes(0)/m/n/12.045 USA:
+....\glue 3.01125 plus 1.50562 minus 1.00374
+....\TU/texgyretermes(0)/m/n/12.045 Addison-Wesley,
+....\glue 3.01125 plus 1.88202 minus 0.80298
+....\TU/texgyretermes(0)/m/n/12.045 1986.
 ....\penalty 10000
 ....\glue(\parfillskip) 0.0 plus 1.0fil
 ....\glue(\rightskip) 0.0
+...\penalty -51
+...\glue 0.0 plus 0.2
+...\glue 0.0 plus -0.2
 ...\glue 0.0 plus 1.0fil
 ...\glue 0.0
 ...\glue 0.0 plus 0.0001fil
-..\glue(\baselineskip) 7.63202
-..\hbox(14.84546+3.5232)x417.11752
+..\glue(\baselineskip) 8.23427
+..\hbox(14.24321+3.5232)x417.11752
 ...\special{color push  Black}
-...\hbox(14.84546+3.5232)x417.11752
+...\hbox(14.24321+3.5232)x417.11752
 ....\glue 0.0 plus 1.0fil minus 1.0fil
-....\hbox(14.84546+3.5232)x417.11752
-.....\vbox(14.84546+3.5232)x417.11752
+....\hbox(14.24321+3.5232)x417.11752
+.....\vbox(14.24321+3.5232)x417.11752
 ......\rule(0.0+0.0)x417.11752
-......\glue 6.6248
+......\glue 6.02255
 ......\hbox(8.22066+3.5232)x417.11752
 .......\hbox(0.0+0.0)x0.0, glue set - 417.11752fil
 ........\vbox(0.0+0.0)x417.11752
@@ -4942,6 +5056,7 @@ Completed box being shipped out [8]
 ..........\glue(\parfillskip) 0.0
 ..........\glue(\rightskip) 0.0
 ...\special{color pop}
+Appendix A
 Completed box being shipped out [9]
 \vbox(722.98453+3.5232)x435.04271
 .\glue -29.59128
@@ -5017,10 +5132,10 @@ Completed box being shipped out [9]
 ....\special{color pop}
 ..\glue 15.6491
 ..\glue(\lineskip) 0.0
-..\vbox(700.50723+0.0)x417.11752, glue set 582.43301fil
+..\vbox(700.50723+0.0)x417.11752, glue set 610.62532fil
 ...\write-{}
-...\write2{\@writefile{toc}{\protect \addvspace {12bp}}}
-...\write2{\@writefile{toc}{\protect \contentsline {chapter}{Bibliography}{\thepage }{}\protected@file@percent }}
+...\write2{\pp@pagectr{footnote}{4}{\theabspage }{\thepage }}
+...\write2{\@writefile{toc}{\protect \contentsline {chapter}{\protect \numberline {Appendix A}附录章节}{\thepage }{}\protected@file@percent }}
 ...\glue(\topskip) 12.0
 ...\rule(0.0+0.0)x*
 ...\penalty 10000
@@ -5028,12 +5143,24 @@ Completed box being shipped out [9]
 ...\glue 0.0
 ...\glue(\parskip) 0.0
 ...\glue(\parskip) 0.0
-...\glue(\baselineskip) 19.95255
-...\hbox(13.1712+3.93869)x417.11752, glue set 159.08095fil
+...\glue(\baselineskip) 16.88107
+...\hbox(12.55891+3.50107)x417.11752, glue set 127.34335fil
 ....\glue(\leftskip) 0.0 plus 1.0fil
-....\TU/texgyreheros(0)/m/n/18.06749 Bibliography
+....\TU/texgyreheros(0)/m/n/16.06 Appendix
+....\glue 4.46468 plus 2.23233 minus 1.48822
+....\TU/texgyreheros(0)/m/n/16.06 A
 ....\kern -0.0002
 ....\kern 0.0002
+....\glue 16.06
+....\TU/FandolHei(0)/m/n/16.06 附
+....\glue 0.0 plus 1.37729
+....\TU/FandolHei(0)/m/n/16.06 录
+....\glue 0.0 plus 1.37729
+....\TU/FandolHei(0)/m/n/16.06 章
+....\glue 0.0 plus 1.37729
+....\TU/FandolHei(0)/m/n/16.06 节
+....\kern -0.00017
+....\kern 0.00017
 ....\penalty 10000
 ....\glue(\parfillskip) 0.0
 ....\glue(\rightskip) 0.0 plus 1.0fil
@@ -5041,103 +5168,37 @@ Completed box being shipped out [9]
 ...\glue 19.07124
 ...\glue(\parskip) 0.0
 ...\glue(\parskip) 0.0
-...\glue(\baselineskip) 9.91707
-...\hbox(8.22673+2.71011)x387.00504, glue set - 0.07979, shifted 30.11249
-....\hbox(8.14243+1.879)x0.0
-.....\glue 0.0
-.....\glue -30.11249
-.....\glue 0.0
-.....\hbox(8.14243+1.879)x30.11249, glue set 16.06802fill
-......\special{color push  Black}
-......\glue 0.0 plus 1.0fil
-......\glue 0.0 plus 1.0fil
-......\TU/texgyretermes(0)/m/n/12.045 [1]
-......\kern -0.0002
-......\kern 0.0002
-......\glue 0.0 plus 1.0fill
-......\special{color pop}
-.....\glue 0.0
-....\penalty 0
-....\TU/texgyretermes(0)/m/n/12.045 KNUTH
-....\kern -0.0002
-....\kern 0.0002
+...\glue(\baselineskip) 7.26314
+...\hbox(9.31079+2.20422)x417.11752, glue set 340.55951fil
+....\hbox(0.0+0.0)x24.09
+....\TU/FandolSong(0)/m/n/12.045 附
+....\glue 0.0 plus 0.61353
+....\TU/FandolSong(0)/m/n/12.045 录
+....\glue 0.0 plus 0.61353
+....\TU/FandolSong(0)/m/n/12.045 内
+....\glue 0.0 plus 0.61353
+....\TU/FandolSong(0)/m/n/12.045 容
 ....\penalty 10000
-....\glue 3.01125 plus 1.50562 minus 1.00374
-....\TU/texgyretermes(0)/m/n/12.045 D
-....\kern -0.0002
-....\kern 0.0002
-....\penalty 10000
-....\glue 3.01125 plus 1.50562 minus 1.00374
-....\TU/texgyretermes(0)/m/n/12.045 E.
-....\glue 3.01125 plus 1.50562 minus 1.00374
-....\glue 1.32495 plus 3.97487 minus 0.84323
-....\TU/texgyretermes(0)/m/n/12.045 Computers
-....\glue 3.01125 plus 1.50562 minus 1.00374
-....\TU/texgyretermes(0)/m/n/12.045 and
-....\glue 3.01125 plus 1.50562 minus 1.00374
-....\TU/texgyretermes(0)/m/n/12.045 typesetting:
-....\glue 4.01498 plus 3.01123 minus 0.50186
-....\TU/texgyretermes(0)/m/n/12.045 volume
-....\kern -0.0002
-....\kern 0.0002
-....\penalty 10000
-....\glue 3.01125 plus 1.50562 minus 1.00374
-....\TU/texgyretermes(0)/m/n/12.045 A
-....\kern -0.0002
-....\kern 0.0002
-....\glue 12.045
-....\TU/texgyretermes(0)/m/n/12.045 The
-....\glue 3.01125 plus 1.50562 minus 1.00374
-....\TU/texgyretermes(0)/m/n/12.045 T
-....\kern -0.0002
-....\kern 0.0002
-....\kern -2.00792
-....\hbox(7.97379+0.0)x7.3595, shifted 2.71011
-.....\TU/texgyretermes(0)/m/n/12.045 E
-.....\kern -0.0002
-.....\kern 0.0002
-....\kern -1.50562
-....\TU/texgyretermes(0)/m/n/12.045 X
-....\kern -0.0002
-....\kern 0.0002
-....\TU/texgyretermes(0)/m/n/12.045 book
-....\kern -0.0002
-....\kern 0.0002
-....\penalty 0
-....\TU/texgyretermes(0)/m/n/12.045 [M].
-....\glue 3.01125 plus 1.50562 minus 1.00374
-....\glue 1.32495 plus 3.97487 minus 0.84323
-....\TU/texgyretermes(0)/m/n/12.045 Read-
-....\glue(\rightskip) 0.0
-...\penalty 14100
-...\glue(\baselineskip) 11.13359
-...\hbox(8.23878+2.6258)x387.00504, glue set 199.12717fil, shifted 30.11249
-....\TU/texgyretermes(0)/m/n/12.045 ing,
-....\glue 3.01125 plus 1.88202 minus 0.80298
-....\TU/texgyretermes(0)/m/n/12.045 MA,
-....\glue 3.01125 plus 1.50562 minus 1.00374
-....\TU/texgyretermes(0)/m/n/12.045 USA:
-....\glue 3.01125 plus 1.50562 minus 1.00374
-....\TU/texgyretermes(0)/m/n/12.045 Addison-Wesley,
-....\glue 3.01125 plus 1.88202 minus 0.80298
-....\TU/texgyretermes(0)/m/n/12.045 1986.
+....\TU/FandolSong(0)/m/n/12.045 。
+....\rule(0.0+0.0)x-7.75697
+....\kern 0.00047
+....\kern -0.00047
+....\kern -0.18753
+....\kern 0.18753
 ....\penalty 10000
 ....\glue(\parfillskip) 0.0 plus 1.0fil
 ....\glue(\rightskip) 0.0
-...\penalty -51
-...\glue 0.0 plus 0.2
-...\glue 0.0 plus -0.2
 ...\glue 0.0 plus 1.0fil
 ...\glue 0.0
 ...\glue 0.0 plus 0.0001fil
-..\glue(\baselineskip) 7.63202
-..\hbox(14.84546+3.5232)x417.11752
+..\glue(\baselineskip) 8.23427
+..\hbox(14.24321+3.5232)x417.11752
 ...\special{color push  Black}
-...\hbox(14.84546+3.5232)x417.11752
-....\hbox(14.84546+3.5232)x417.11752
-.....\vbox(14.84546+3.5232)x417.11752
+...\hbox(14.24321+3.5232)x417.11752
+....\hbox(14.24321+3.5232)x417.11752
+.....\vbox(14.24321+3.5232)x417.11752
 ......\rule(0.0+0.0)x417.11752
-......\glue 6.6248
+......\glue 6.02255
 ......\hbox(8.22066+3.5232)x417.11752
 .......\hbox(0.0+0.0)x0.0, glue set - 417.11752fil
 ........\vbox(0.0+0.0)x417.11752
@@ -5171,7 +5232,7 @@ Completed box being shipped out [9]
 ..........\glue(\rightskip) 0.0
 ....\glue 0.0 plus 1.0fil minus 1.0fil
 ...\special{color pop}
-Appendix A
+)
 Completed box being shipped out [10]
 \vbox(722.98453+3.5232)x435.04271
 .\glue -29.59128
@@ -5247,10 +5308,10 @@ Completed box being shipped out [10]
 ....\special{color pop}
 ..\glue 15.6491
 ..\glue(\lineskip) 0.0
-..\vbox(700.50723+0.0)x417.11752, glue set 608.61804fil
+..\vbox(700.50723+0.0)x417.11752, glue set 566.9528fil
 ...\write-{}
-...\write2{\pp@pagectr{footnote}{4}{\theabspage }{\thepage }}
-...\write2{\@writefile{toc}{\protect \contentsline {chapter}{\protect \numberline {Appendix A}附录章节}{\thepage }{}\protected@file@percent }}
+...\write-{}
+...\write2{\@writefile{toc}{\protect \contentsline {chapter}{Acknowledgements}{\thepage }{}\protected@file@percent }}
 ...\glue(\topskip) 12.0
 ...\rule(0.0+0.0)x*
 ...\penalty 10000
@@ -5258,24 +5319,12 @@ Completed box being shipped out [10]
 ...\glue 0.0
 ...\glue(\parskip) 0.0
 ...\glue(\parskip) 0.0
-...\glue(\baselineskip) 16.88107
-...\hbox(12.55891+3.50107)x417.11752, glue set 127.34335fil
+...\glue(\baselineskip) 19.95255
+...\hbox(13.1712+3.93869)x417.11752, glue set 130.3717fil
 ....\glue(\leftskip) 0.0 plus 1.0fil
-....\TU/texgyreheros(0)/m/n/16.06 Appendix
-....\glue 4.46468 plus 2.23233 minus 1.48822
-....\TU/texgyreheros(0)/m/n/16.06 A
+....\TU/texgyreheros(0)/m/n/18.06749 Acknowledgements
 ....\kern -0.0002
 ....\kern 0.0002
-....\glue 16.06
-....\TU/FandolHei(0)/m/n/16.06 附
-....\glue 0.0 plus 1.37729
-....\TU/FandolHei(0)/m/n/16.06 录
-....\glue 0.0 plus 1.37729
-....\TU/FandolHei(0)/m/n/16.06 章
-....\glue 0.0 plus 1.37729
-....\TU/FandolHei(0)/m/n/16.06 节
-....\kern -0.00017
-....\kern 0.00017
 ....\penalty 10000
 ....\glue(\parfillskip) 0.0
 ....\glue(\rightskip) 0.0 plus 1.0fil
@@ -5283,12 +5332,12 @@ Completed box being shipped out [10]
 ...\glue 19.07124
 ...\glue(\parskip) 0.0
 ...\glue(\parskip) 0.0
-...\glue(\baselineskip) 9.27063
-...\hbox(9.31079+2.20422)x417.11752, glue set 340.55951fil
+...\glue(\baselineskip) 6.81348
+...\hbox(9.32283+2.20422)x417.11752, glue set 340.55951fil
 ....\hbox(0.0+0.0)x24.09
-....\TU/FandolSong(0)/m/n/12.045 附
+....\TU/FandolSong(0)/m/n/12.045 致
 ....\glue 0.0 plus 0.61353
-....\TU/FandolSong(0)/m/n/12.045 录
+....\TU/FandolSong(0)/m/n/12.045 谢
 ....\glue 0.0 plus 0.61353
 ....\TU/FandolSong(0)/m/n/12.045 内
 ....\glue 0.0 plus 0.61353
@@ -5303,18 +5352,38 @@ Completed box being shipped out [10]
 ....\penalty 10000
 ....\glue(\parfillskip) 0.0 plus 1.0fil
 ....\glue(\rightskip) 0.0
+...\glue(\baselineskip) 17.87077
+...\hbox(0.0+0.0)x0.0
+...\glue(\parskip) 0.0
+...\glue(\parskip) 0.0
+...\glue(\baselineskip) 10.77626
+...\hbox(9.29874+2.04764)x417.11752, glue set 353.88129fil
+....\glue(\leftskip) 0.0 plus 1.0fil
+....\hbox(0.0+0.0)x0.0
+....\TU/texgyretermes(0)/m/n/12.045 2016
+....\glue 3.01125 plus 1.50562 minus 1.00374
+....\TU/FandolSong(0)/m/n/12.045 年
+....\glue 3.01125 plus 1.50562 minus 1.00374
+....\TU/texgyretermes(0)/m/n/12.045 5
+....\glue 3.01125 plus 1.50562 minus 1.00374
+....\TU/FandolSong(0)/m/n/12.045 月
+....\kern -0.00017
+....\kern 0.00017
+....\penalty 10000
+....\glue(\parfillskip) 0.0
+....\glue(\rightskip) 0.0
 ...\glue 0.0 plus 1.0fil
 ...\glue 0.0
 ...\glue 0.0 plus 0.0001fil
-..\glue(\baselineskip) 7.63202
-..\hbox(14.84546+3.5232)x417.11752
+..\glue(\baselineskip) 8.23427
+..\hbox(14.24321+3.5232)x417.11752
 ...\special{color push  Black}
-...\hbox(14.84546+3.5232)x417.11752
+...\hbox(14.24321+3.5232)x417.11752
 ....\glue 0.0 plus 1.0fil minus 1.0fil
-....\hbox(14.84546+3.5232)x417.11752
-.....\vbox(14.84546+3.5232)x417.11752
+....\hbox(14.24321+3.5232)x417.11752
+.....\vbox(14.24321+3.5232)x417.11752
 ......\rule(0.0+0.0)x417.11752
-......\glue 6.6248
+......\glue 6.02255
 ......\hbox(8.22066+3.5232)x417.11752
 .......\hbox(0.0+0.0)x0.0, glue set - 417.11752fil
 ........\vbox(0.0+0.0)x417.11752
@@ -5346,188 +5415,4 @@ Completed box being shipped out [10]
 ..........\penalty 10000
 ..........\glue(\parfillskip) 0.0
 ..........\glue(\rightskip) 0.0
-...\special{color pop}
-)
-Completed box being shipped out [11]
-\vbox(722.98453+3.5232)x435.04271
-.\glue -29.59128
-.\vbox(752.5758+3.5232)x417.11752, shifted 17.92519
-..\vbox(13.942+0.0)x417.11752, glue set 2.19815fil
-...\glue 0.0 plus 1.0fil
-...\hbox(11.74385+0.0)x417.11752
-....\special{color push  Black}
-....\hbox(11.74385+0.0)x417.11752
-.....\hbox(11.74385+0.0)x417.11752
-......\vbox(11.74385+0.0)x417.11752
-.......\hbox(8.22066+3.5232)x417.11752
-........\hbox(0.0+0.0)x0.0, glue set - 417.11752fil
-.........\vbox(0.0+0.0)x417.11752
-..........\hbox(0.0+0.0)x417.11752, glue set 208.55876fil
-...........\hbox(0.0+0.0)x0.0
-...........\penalty 10000
-...........\glue(\parfillskip) 0.0 plus 1.0fil
-...........\glue(\rightskip) 0.0 plus 1.0fil
-.........\glue 0.0 plus 1.0fil minus 1.0fil
-........\glue 0.0 plus 1.0fill
-........\vbox(8.22066+3.5232)x417.11752
-.........\hbox(8.22066+3.5232)x417.11752, glue set 145.3226fil
-..........\glue(\leftskip) 0.0 plus 1.0fil
-..........\hbox(0.0+0.0)x0.0
-..........\TU/FandolSong(0)/m/n/9.03374 中
-..........\glue 0.0 plus 0.24089
-..........\TU/FandolSong(0)/m/n/9.03374 国
-..........\glue 0.0 plus 0.24089
-..........\TU/FandolSong(0)/m/n/9.03374 科
-..........\glue 0.0 plus 0.24089
-..........\TU/FandolSong(0)/m/n/9.03374 学
-..........\glue 0.0 plus 0.24089
-..........\TU/FandolSong(0)/m/n/9.03374 技
-..........\glue 0.0 plus 0.24089
-..........\TU/FandolSong(0)/m/n/9.03374 术
-..........\glue 0.0 plus 0.24089
-..........\TU/FandolSong(0)/m/n/9.03374 大
-..........\glue 0.0 plus 0.24089
-..........\TU/FandolSong(0)/m/n/9.03374 学
-..........\glue 0.0 plus 0.24089
-..........\TU/FandolSong(0)/m/n/9.03374 本
-..........\glue 0.0 plus 0.24089
-..........\TU/FandolSong(0)/m/n/9.03374 科
-..........\glue 0.0 plus 0.24089
-..........\TU/FandolSong(0)/m/n/9.03374 毕
-..........\glue 0.0 plus 0.24089
-..........\TU/FandolSong(0)/m/n/9.03374 业
-..........\glue 0.0 plus 0.24089
-..........\TU/FandolSong(0)/m/n/9.03374 论
-..........\glue 0.0 plus 0.24089
-..........\TU/FandolSong(0)/m/n/9.03374 文
-..........\kern -0.00017
-..........\kern 0.00017
-..........\rule(8.22066+3.5232)x0.0
-..........\penalty 10000
-..........\glue(\parfillskip) 0.0
-..........\glue(\rightskip) 0.0 plus 1.0fil
-........\glue 0.0 plus 1.0fill
-........\hbox(0.0+0.0)x0.0, glue set - 417.11752fil
-.........\glue 0.0 plus 1.0fil minus 1.0fil
-.........\vbox(0.0+0.0)x417.11752
-..........\hbox(0.0+0.0)x417.11752, glue set 417.11752fil
-...........\glue(\leftskip) 0.0 plus 1.0fil
-...........\hbox(0.0+0.0)x0.0
-...........\penalty 10000
-...........\glue(\parfillskip) 0.0
-...........\glue(\rightskip) 0.0
-.......\glue 0.0
-.......\rule(0.7528+0.0)x417.11752
-.......\glue -0.7528
-.....\glue 0.0 plus 1.0fil minus 1.0fil
-....\special{color pop}
-..\glue 15.6491
-..\glue(\lineskip) 0.0
-..\vbox(700.50723+0.0)x417.11752, glue set 560.93097fil
-...\write-{}
-...\write-{}
-...\write2{\@writefile{toc}{\protect \contentsline {chapter}{Acknowledgements}{\thepage }{}\protected@file@percent }}
-...\glue(\topskip) 12.0
-...\rule(0.0+0.0)x*
-...\penalty 10000
-...\glue 7.02625
-...\glue 0.0
-...\glue(\parskip) 0.0
-...\glue(\parskip) 0.0
-...\glue(\baselineskip) 19.95255
-...\hbox(13.1712+3.93869)x417.11752, glue set 130.3717fil
-....\glue(\leftskip) 0.0 plus 1.0fil
-....\TU/texgyreheros(0)/m/n/18.06749 Acknowledgements
-....\kern -0.0002
-....\kern 0.0002
-....\penalty 10000
-....\glue(\parfillskip) 0.0
-....\glue(\rightskip) 0.0 plus 1.0fil
-...\penalty 10000
-...\glue 19.07124
-...\glue(\parskip) 0.0
-...\glue(\parskip) 0.0
-...\glue(\baselineskip) 8.82097
-...\hbox(9.32283+2.20422)x417.11752, glue set 340.55951fil
-....\hbox(0.0+0.0)x24.09
-....\TU/FandolSong(0)/m/n/12.045 致
-....\glue 0.0 plus 0.61353
-....\TU/FandolSong(0)/m/n/12.045 谢
-....\glue 0.0 plus 0.61353
-....\TU/FandolSong(0)/m/n/12.045 内
-....\glue 0.0 plus 0.61353
-....\TU/FandolSong(0)/m/n/12.045 容
-....\penalty 10000
-....\TU/FandolSong(0)/m/n/12.045 。
-....\rule(0.0+0.0)x-7.75697
-....\kern 0.00047
-....\kern -0.00047
-....\kern -0.18753
-....\kern 0.18753
-....\penalty 10000
-....\glue(\parfillskip) 0.0 plus 1.0fil
-....\glue(\rightskip) 0.0
-...\glue(\baselineskip) 19.87827
-...\hbox(0.0+0.0)x0.0
-...\glue(\parskip) 0.0
-...\glue(\parskip) 0.0
-...\glue(\baselineskip) 12.78375
-...\hbox(9.29874+2.04764)x417.11752, glue set 353.88129fil
-....\glue(\leftskip) 0.0 plus 1.0fil
-....\hbox(0.0+0.0)x0.0
-....\TU/texgyretermes(0)/m/n/12.045 2016
-....\glue 3.01125 plus 1.50562 minus 1.00374
-....\TU/FandolSong(0)/m/n/12.045 年
-....\glue 3.01125 plus 1.50562 minus 1.00374
-....\TU/texgyretermes(0)/m/n/12.045 5
-....\glue 3.01125 plus 1.50562 minus 1.00374
-....\TU/FandolSong(0)/m/n/12.045 月
-....\kern -0.00017
-....\kern 0.00017
-....\penalty 10000
-....\glue(\parfillskip) 0.0
-....\glue(\rightskip) 0.0
-...\glue 0.0 plus 1.0fil
-...\glue 0.0
-...\glue 0.0 plus 0.0001fil
-..\glue(\baselineskip) 7.63202
-..\hbox(14.84546+3.5232)x417.11752
-...\special{color push  Black}
-...\hbox(14.84546+3.5232)x417.11752
-....\hbox(14.84546+3.5232)x417.11752
-.....\vbox(14.84546+3.5232)x417.11752
-......\rule(0.0+0.0)x417.11752
-......\glue 6.6248
-......\hbox(8.22066+3.5232)x417.11752
-.......\hbox(0.0+0.0)x0.0, glue set - 417.11752fil
-........\vbox(0.0+0.0)x417.11752
-.........\hbox(0.0+0.0)x417.11752, glue set 208.55876fil
-..........\hbox(0.0+0.0)x0.0
-..........\penalty 10000
-..........\glue(\parfillskip) 0.0 plus 1.0fil
-..........\glue(\rightskip) 0.0 plus 1.0fil
-........\glue 0.0 plus 1.0fil minus 1.0fil
-.......\glue 0.0 plus 1.0fill
-.......\vbox(8.22066+3.5232)x417.11752
-........\hbox(8.22066+3.5232)x417.11752, glue set 204.0419fil
-.........\glue(\leftskip) 0.0 plus 1.0fil
-.........\hbox(0.0+0.0)x0.0
-.........\TU/texgyretermes(0)/m/n/9.03374 11
-.........\kern -0.0002
-.........\kern 0.0002
-.........\rule(8.22066+3.5232)x0.0
-.........\penalty 10000
-.........\glue(\parfillskip) 0.0
-.........\glue(\rightskip) 0.0 plus 1.0fil
-.......\glue 0.0 plus 1.0fill
-.......\hbox(0.0+0.0)x0.0, glue set - 417.11752fil
-........\glue 0.0 plus 1.0fil minus 1.0fil
-........\vbox(0.0+0.0)x417.11752
-.........\hbox(0.0+0.0)x417.11752, glue set 417.11752fil
-..........\glue(\leftskip) 0.0 plus 1.0fil
-..........\hbox(0.0+0.0)x0.0
-..........\penalty 10000
-..........\glue(\parfillskip) 0.0
-..........\glue(\rightskip) 0.0
-....\glue 0.0 plus 1.0fil minus 1.0fil
 ...\special{color pop}

--- a/test/testfiles-crossref/main-bachelor-english.tlg
+++ b/test/testfiles-crossref/main-bachelor-english.tlg
@@ -777,7 +777,7 @@ Completed box being shipped out [1]
 ....\special{color pop}
 ..\glue 15.6491
 ..\glue(\lineskip) 0.0
-..\vbox(700.50723+0.0)x417.11752, glue set 346.19151fil
+..\vbox(700.50723+0.0)x417.11752, glue set 382.32265fil
 ...\write-{}
 ...\write-{}
 ...\write-{}
@@ -805,24 +805,24 @@ Completed box being shipped out [1]
 ...\glue(\parskip) 0.0
 ...\glue(\parskip) 0.0
 ...\glue(\baselineskip) 5.69737
-...\hbox(14.05243+6.02255)x417.11752, glue set 324.78058fill
-....\glue(\leftskip) 59.21321
+...\hbox(14.05243+6.02255)x417.11752, glue set 320.21552fill
+....\glue(\leftskip) 63.77827
 ....\hbox(0.0+0.0)x0.0
 ....\rule(14.05243+6.02255)x0.0
-....\hbox(8.22673+2.61375)x0.0, glue set - 59.21321fil
+....\hbox(8.32309+2.46921)x0.0, glue set - 63.77827fil
 .....\glue 0.0 plus 1.0fil minus 1.0fil
-.....\hbox(8.22673+2.61375)x59.21321
+.....\hbox(8.32309+2.46921)x63.77827
 ......\special{color push  Black}
-......\TU/texgyretermes(0)/m/n/12.045 Chapter
+......\TU/texgyretermes(0)/b/n/12.045 Chapter
 ......\glue 3.01125 plus 1.50562 minus 1.00374
-......\TU/texgyretermes(0)/m/n/12.045 1
+......\TU/texgyretermes(0)/b/n/12.045 1
 ......\kern -0.0002
 ......\kern 0.0002
 ......\glue 12.045
 ......\special{color pop}
-....\TU/FandolSong(0)/m/n/12.045 引
+....\TU/FandolSong(0)/b/n/12.045 引
 ....\glue 0.0 plus 0.61353
-....\TU/FandolSong(0)/m/n/12.045 言
+....\TU/FandolSong(0)/b/n/12.045 言
 ....\kern -0.00017
 ....\kern 0.00017
 ....\rule(14.05243+6.02255)x0.0
@@ -854,8 +854,8 @@ Completed box being shipped out [1]
 ...\glue(\parskip) 0.0
 ...\glue(\parskip) 0.0
 ...\glue(\baselineskip) 0.00002
-...\hbox(14.05243+6.02255)x417.11752, glue set 224.39757fill
-....\glue(\leftskip) 39.14624
+...\hbox(14.05243+6.02255)x417.11752, glue set 212.35257fill
+....\glue(\leftskip) 51.19124
 ....\hbox(0.0+0.0)x0.0
 ....\rule(14.05243+6.02255)x0.0
 ....\hbox(8.14243+0.13248)x0.0, glue set - 27.10124fil
@@ -921,8 +921,8 @@ Completed box being shipped out [1]
 ...\glue(\parskip) 0.0
 ...\glue(\parskip) 0.0
 ...\glue(\baselineskip) 0.00002
-...\hbox(14.05243+6.02255)x417.11752, glue set 275.5888fill
-....\glue(\leftskip) 60.22499
+...\hbox(14.05243+6.02255)x417.11752, glue set 251.49881fill
+....\glue(\leftskip) 84.31499
 ....\hbox(0.0+0.0)x0.0
 ....\rule(14.05243+6.02255)x0.0
 ....\hbox(8.14243+0.13248)x0.0, glue set - 36.135fil
@@ -970,38 +970,34 @@ Completed box being shipped out [1]
 ....\glue(\parfillskip) 0.0 plus 1.0fil
 ....\glue(\rightskip) 0.0
 ...\penalty 10000
-...\glue 12.045
-...\glue -18.045
 ...\penalty -300
-...\glue 6.0
-...\glue 12.045
 ...\glue 0.0 plus 0.1
 ...\penalty 10000
 ...\glue(\parskip) 0.0
 ...\glue(\parskip) 0.0
 ...\glue(\baselineskip) 0.00002
-...\hbox(14.05243+6.02255)x417.11752, glue set 300.69058fill
-....\glue(\leftskip) 59.21321
+...\hbox(14.05243+6.02255)x417.11752, glue set 296.12552fill
+....\glue(\leftskip) 63.77827
 ....\hbox(0.0+0.0)x0.0
 ....\rule(14.05243+6.02255)x0.0
-....\hbox(8.22673+2.61375)x0.0, glue set - 59.21321fil
+....\hbox(8.32309+2.46921)x0.0, glue set - 63.77827fil
 .....\glue 0.0 plus 1.0fil minus 1.0fil
-.....\hbox(8.22673+2.61375)x59.21321
+.....\hbox(8.32309+2.46921)x63.77827
 ......\special{color push  Black}
-......\TU/texgyretermes(0)/m/n/12.045 Chapter
+......\TU/texgyretermes(0)/b/n/12.045 Chapter
 ......\glue 3.01125 plus 1.50562 minus 1.00374
-......\TU/texgyretermes(0)/m/n/12.045 2
+......\TU/texgyretermes(0)/b/n/12.045 2
 ......\kern -0.0002
 ......\kern 0.0002
 ......\glue 12.045
 ......\special{color pop}
-....\TU/FandolSong(0)/m/n/12.045 内
+....\TU/FandolSong(0)/b/n/12.045 内
 ....\glue 0.0 plus 0.61353
-....\TU/FandolSong(0)/m/n/12.045 容
+....\TU/FandolSong(0)/b/n/12.045 容
 ....\glue 0.0 plus 0.61353
-....\TU/FandolSong(0)/m/n/12.045 要
+....\TU/FandolSong(0)/b/n/12.045 要
 ....\glue 0.0 plus 0.61353
-....\TU/FandolSong(0)/m/n/12.045 素
+....\TU/FandolSong(0)/b/n/12.045 素
 ....\kern -0.00017
 ....\kern 0.00017
 ....\rule(14.05243+6.02255)x0.0
@@ -1033,8 +1029,8 @@ Completed box being shipped out [1]
 ...\glue(\parskip) 0.0
 ...\glue(\parskip) 0.0
 ...\glue(\baselineskip) 0.00002
-...\hbox(14.05243+6.02255)x417.11752, glue set 260.53256fill
-....\glue(\leftskip) 39.14624
+...\hbox(14.05243+6.02255)x417.11752, glue set 248.48756fill
+....\glue(\leftskip) 51.19124
 ....\hbox(0.0+0.0)x0.0
 ....\rule(14.05243+6.02255)x0.0
 ....\hbox(8.14243+0.13248)x0.0, glue set - 27.10124fil
@@ -1096,8 +1092,8 @@ Completed box being shipped out [1]
 ...\glue(\parskip) 0.0
 ...\glue(\parskip) 0.0
 ...\glue(\baselineskip) 0.00002
-...\hbox(14.05243+6.02255)x417.11752, glue set 323.7688fill
-....\glue(\leftskip) 60.22499
+...\hbox(14.05243+6.02255)x417.11752, glue set 299.6788fill
+....\glue(\leftskip) 84.31499
 ....\hbox(0.0+0.0)x0.0
 ....\rule(14.05243+6.02255)x0.0
 ....\hbox(8.14243+0.13248)x0.0, glue set - 36.135fil
@@ -1143,8 +1139,8 @@ Completed box being shipped out [1]
 ...\glue(\parskip) 0.0
 ...\glue(\parskip) 0.0
 ...\glue(\baselineskip) 0.00002
-...\hbox(14.05243+6.02255)x417.11752, glue set 323.7688fill
-....\glue(\leftskip) 60.22499
+...\hbox(14.05243+6.02255)x417.11752, glue set 299.6788fill
+....\glue(\leftskip) 84.31499
 ....\hbox(0.0+0.0)x0.0
 ....\rule(14.05243+6.02255)x0.0
 ....\hbox(8.14243+0.13248)x0.0, glue set - 36.135fil
@@ -1190,8 +1186,8 @@ Completed box being shipped out [1]
 ...\glue(\parskip) 0.0
 ...\glue(\parskip) 0.0
 ...\glue(\baselineskip) 0.00002
-...\hbox(14.05243+6.02255)x417.11752, glue set 311.7238fill
-....\glue(\leftskip) 60.22499
+...\hbox(14.05243+6.02255)x417.11752, glue set 287.6338fill
+....\glue(\leftskip) 84.31499
 ....\hbox(0.0+0.0)x0.0
 ....\rule(14.05243+6.02255)x0.0
 ....\hbox(8.14243+0.16861)x0.0, glue set - 36.135fil
@@ -1233,34 +1229,30 @@ Completed box being shipped out [1]
 ....\glue(\parfillskip) 0.0 plus 1.0fil
 ....\glue(\rightskip) 0.0
 ...\penalty 10000
-...\glue 12.045
-...\glue -18.045
 ...\penalty -300
-...\glue 6.0
-...\glue 12.045
 ...\glue 0.0 plus 0.1
 ...\penalty 10000
 ...\glue(\parskip) 0.0
 ...\glue(\parskip) 0.0
 ...\glue(\baselineskip) 0.00002
-...\hbox(14.05243+6.02255)x417.11752, glue set 324.78058fill
-....\glue(\leftskip) 59.21321
+...\hbox(14.05243+6.02255)x417.11752, glue set 320.21552fill
+....\glue(\leftskip) 63.77827
 ....\hbox(0.0+0.0)x0.0
 ....\rule(14.05243+6.02255)x0.0
-....\hbox(8.22673+2.61375)x0.0, glue set - 59.21321fil
+....\hbox(8.32309+2.46921)x0.0, glue set - 63.77827fil
 .....\glue 0.0 plus 1.0fil minus 1.0fil
-.....\hbox(8.22673+2.61375)x59.21321
+.....\hbox(8.32309+2.46921)x63.77827
 ......\special{color push  Black}
-......\TU/texgyretermes(0)/m/n/12.045 Chapter
+......\TU/texgyretermes(0)/b/n/12.045 Chapter
 ......\glue 3.01125 plus 1.50562 minus 1.00374
-......\TU/texgyretermes(0)/m/n/12.045 3
+......\TU/texgyretermes(0)/b/n/12.045 3
 ......\kern -0.0002
 ......\kern 0.0002
 ......\glue 12.045
 ......\special{color pop}
-....\TU/FandolSong(0)/m/n/12.045 引
+....\TU/FandolSong(0)/b/n/12.045 引
 ....\glue 0.0 plus 0.61353
-....\TU/FandolSong(0)/m/n/12.045 用
+....\TU/FandolSong(0)/b/n/12.045 用
 ....\kern -0.00017
 ....\kern 0.00017
 ....\rule(14.05243+6.02255)x0.0
@@ -1286,20 +1278,16 @@ Completed box being shipped out [1]
 ....\glue(\parfillskip) 0.0 plus 1.0fil
 ....\glue(\rightskip) 0.0
 ...\penalty 10000
-...\glue 12.045
-...\glue -18.045
 ...\penalty 0
-...\glue 6.0
-...\glue 12.045
 ...\glue 0.0 plus 0.1
 ...\penalty 10000
 ...\glue(\parskip) 0.0
 ...\glue(\parskip) 0.0
 ...\glue(\baselineskip) 0.00002
-...\hbox(14.05243+6.02255)x417.11752, glue set 344.75117fill
+...\hbox(14.05243+6.02255)x417.11752, glue set 340.89679fill
 ....\hbox(0.0+0.0)x0.0
 ....\rule(14.05243+6.02255)x0.0
-....\TU/texgyretermes(0)/m/n/12.045 Bibliography
+....\TU/texgyretermes(0)/b/n/12.045 Bibliography
 ....\kern -0.0002
 ....\kern 0.0002
 ....\rule(14.05243+6.02255)x0.0
@@ -1331,28 +1319,28 @@ Completed box being shipped out [1]
 ...\glue(\parskip) 0.0
 ...\glue(\parskip) 0.0
 ...\glue(\baselineskip) 0.00002
-...\hbox(14.05243+6.02255)x417.11752, glue set 288.64558fill
-....\glue(\leftskip) 71.25821
+...\hbox(14.05243+6.02255)x417.11752, glue set 285.94751fill
+....\glue(\leftskip) 73.95628
 ....\hbox(0.0+0.0)x0.0
 ....\rule(14.05243+6.02255)x0.0
-....\hbox(8.22673+2.61375)x0.0, glue set - 71.25821fil
+....\hbox(8.31105+2.46921)x0.0, glue set - 73.95628fil
 .....\glue 0.0 plus 1.0fil minus 1.0fil
-.....\hbox(8.22673+2.61375)x71.25821
+.....\hbox(8.31105+2.46921)x73.95628
 ......\special{color push  Black}
-......\TU/texgyretermes(0)/m/n/12.045 Appendix
+......\TU/texgyretermes(0)/b/n/12.045 Appendix
 ......\glue 3.01125 plus 1.50562 minus 1.00374
-......\TU/texgyretermes(0)/m/n/12.045 A
+......\TU/texgyretermes(0)/b/n/12.045 A
 ......\kern -0.0002
 ......\kern 0.0002
 ......\glue 12.045
 ......\special{color pop}
-....\TU/FandolSong(0)/m/n/12.045 附
+....\TU/FandolSong(0)/b/n/12.045 附
 ....\glue 0.0 plus 0.61353
-....\TU/FandolSong(0)/m/n/12.045 录
+....\TU/FandolSong(0)/b/n/12.045 录
 ....\glue 0.0 plus 0.61353
-....\TU/FandolSong(0)/m/n/12.045 章
+....\TU/FandolSong(0)/b/n/12.045 章
 ....\glue 0.0 plus 0.61353
-....\TU/FandolSong(0)/m/n/12.045 节
+....\TU/FandolSong(0)/b/n/12.045 节
 ....\kern -0.00017
 ....\kern 0.00017
 ....\rule(14.05243+6.02255)x0.0
@@ -1384,10 +1372,10 @@ Completed box being shipped out [1]
 ...\glue(\parskip) 0.0
 ...\glue(\parskip) 0.0
 ...\glue(\baselineskip) 0.00002
-...\hbox(14.05243+6.02255)x417.11752, glue set 308.1344fill
+...\hbox(14.05243+6.02255)x417.11752, glue set 303.9307fill
 ....\hbox(0.0+0.0)x0.0
 ....\rule(14.05243+6.02255)x0.0
-....\TU/texgyretermes(0)/m/n/12.045 Acknowledgements
+....\TU/texgyretermes(0)/b/n/12.045 Acknowledgements
 ....\kern -0.0002
 ....\kern 0.0002
 ....\rule(14.05243+6.02255)x0.0
@@ -1965,7 +1953,6 @@ Completed box being shipped out [4]
 ..\vbox(700.50723+0.0)x417.11752, glue set 268.42937fil
 ...\write-{}
 ...\write-{}
-...\write2{\@writefile{toc}{\protect \addvspace {12bp}}}
 ...\write2{\pp@pagectr{footnote}{1}{\theabspage }{\thepage }}
 ...\write2{\@writefile{toc}{\protect \contentsline {chapter}{\protect \numberline {Chapter 1}引言}{\thepage }{}\protected@file@percent }}
 ...\glue(\topskip) 12.0
@@ -3097,7 +3084,6 @@ Completed box being shipped out [5]
 ..\glue(\lineskip) 0.0
 ..\vbox(700.50723+0.0)x417.11752, glue set 15.48946fil
 ...\write-{}
-...\write2{\@writefile{toc}{\protect \addvspace {12bp}}}
 ...\write2{\pp@pagectr{footnote}{2}{\theabspage }{\thepage }}
 ...\write2{\@writefile{toc}{\protect \contentsline {chapter}{\protect \numberline {Chapter 2}内容要素}{\thepage }{}\protected@file@percent }}
 ...\glue(\topskip) 12.0
@@ -4734,7 +4720,6 @@ Completed box being shipped out [7]
 ..\glue(\lineskip) 0.0
 ..\vbox(700.50723+0.0)x417.11752, glue set 630.89862fil
 ...\write-{}
-...\write2{\@writefile{toc}{\protect \addvspace {12bp}}}
 ...\write2{\pp@pagectr{footnote}{3}{\theabspage }{\thepage }}
 ...\write2{\@writefile{toc}{\protect \contentsline {chapter}{\protect \numberline {Chapter 3}引用}{\thepage }{}\protected@file@percent }}
 ...\glue(\topskip) 12.0
@@ -4904,7 +4889,6 @@ Completed box being shipped out [8]
 ..\glue(\lineskip) 0.0
 ..\vbox(700.50723+0.0)x417.11752, glue set 586.44757fil
 ...\write-{}
-...\write2{\@writefile{toc}{\protect \addvspace {12bp}}}
 ...\write2{\@writefile{toc}{\protect \contentsline {chapter}{Bibliography}{\thepage }{}\protected@file@percent }}
 ...\glue(\topskip) 12.0
 ...\rule(0.0+0.0)x*

--- a/test/testfiles-crossref/main-bachelor-english.tlg
+++ b/test/testfiles-crossref/main-bachelor-english.tlg
@@ -2346,8 +2346,7 @@ Completed box being shipped out [4]
 ...\glue(\parskip) 0.0
 ...\glue(\parskip) 0.0
 ...\glue(\baselineskip) 13.47435
-...\hbox(11.8041+2.66495)x417.11752, glue set 100.2291fil
-....\glue(\leftskip) 0.0 plus 1.0fil
+...\hbox(11.8041+2.66495)x417.11752, glue set 200.45818fil
 ....\hbox(10.67488+0.0)x35.98442
 .....\TU/texgyreheros(0)/m/n/15.05624 1.1
 .....\kern -0.0002
@@ -2379,8 +2378,8 @@ Completed box being shipped out [4]
 ....\kern -0.00017
 ....\kern 0.00017
 ....\penalty 10000
-....\glue(\parfillskip) 0.0
-....\glue(\rightskip) 0.0 plus 1.0fil
+....\glue(\parfillskip) 0.0 plus 1.0fil
+....\glue(\rightskip) 0.0
 ...\write2{\@writefile{toc}{\protect \contentsline {section}{\protect \numberline {1.1}学位论文中的常见问题分析}{\thepage }{}\protected@file@percent }}
 ...\penalty 10000
 ...\glue 6.02249
@@ -3119,8 +3118,7 @@ Completed box being shipped out [5]
 ...\glue(\parskip) 0.0
 ...\glue(\parskip) 0.0
 ...\glue(\baselineskip) 12.34312
-...\hbox(11.75893+2.71011)x417.11752, glue set 122.81346fil
-....\glue(\leftskip) 0.0 plus 1.0fil
+...\hbox(11.75893+2.71011)x417.11752, glue set 245.6269fil
 ....\hbox(10.67488+0.0)x35.98442
 .....\TU/texgyreheros(0)/m/n/15.05624 2.1
 .....\kern -0.0002
@@ -3148,8 +3146,8 @@ Completed box being shipped out [5]
 ....\kern -0.00017
 ....\kern 0.00017
 ....\penalty 10000
-....\glue(\parfillskip) 0.0
-....\glue(\rightskip) 0.0 plus 1.0fil
+....\glue(\parfillskip) 0.0 plus 1.0fil
+....\glue(\rightskip) 0.0
 ...\write2{\@writefile{toc}{\protect \contentsline {section}{\protect \numberline {2.1}有关图、表和表达式}{\thepage }{}\protected@file@percent }}
 ...\penalty 10000
 ...\penalty 10000

--- a/test/testfiles-crossref/main-bachelor-english.tlg
+++ b/test/testfiles-crossref/main-bachelor-english.tlg
@@ -97,10 +97,10 @@ Completed box being shipped out [1]
 ...\glue(\parskip) 0.0
 ...\glue(\parskip) 0.0
 ...\glue(\baselineskip) 19.21178
-...\hbox(13.91197+3.14372)x417.11752, glue set 181.45753fil
+...\hbox(13.91197+3.14372)x417.11752, glue set 190.49127fil
 ....\glue(\leftskip) 0.0 plus 1.0fil
 ....\TU/FandolHei(0)/m/n/18.06749 摘
-....\glue 18.06749 plus 0.1423 minus 2.88081
+....\glue 0.0 plus 0.93489
 ....\TU/FandolHei(0)/m/n/18.06749 要
 ....\kern -0.00017
 ....\kern 0.00017

--- a/test/testfiles-crossref/main-bachelor.tlg
+++ b/test/testfiles-crossref/main-bachelor.tlg
@@ -83,7 +83,7 @@ Completed box being shipped out [1]
 ....\special{color pop}
 ..\glue 15.6491
 ..\glue(\lineskip) 0.0
-..\vbox(700.50723+0.0)x417.11752, glue set 494.52197fil
+..\vbox(700.50723+0.0)x417.11752, glue set 506.56564fil
 ...\write-{}
 ...\write-{}
 ...\write-{}
@@ -111,7 +111,7 @@ Completed box being shipped out [1]
 ...\glue 19.07124
 ...\glue(\parskip) 0.0
 ...\glue(\parskip) 0.0
-...\glue(\baselineskip) 9.54367
+...\glue(\baselineskip) 7.53618
 ...\hbox(9.3951+2.32468)x417.11752, glue set 0.41225
 ....\hbox(0.0+0.0)x24.09
 ....\TU/FandolSong(0)/m/n/12.045 研
@@ -181,7 +181,7 @@ Completed box being shipped out [1]
 ....\TU/FandolSong(0)/m/n/12.045 研
 ....\glue(\rightskip) 0.0
 ...\penalty 10150
-...\glue(\baselineskip) 10.36272
+...\glue(\baselineskip) 8.35522
 ...\hbox(9.3951+2.32468)x417.11752, glue set 99.65955fil
 ....\TU/FandolSong(0)/m/n/12.045 究
 ....\glue 0.0 plus 0.61353
@@ -248,7 +248,7 @@ Completed box being shipped out [1]
 ....\glue(\rightskip) 0.0
 ...\glue(\parskip) 0.0
 ...\glue(\parskip) 0.0
-...\glue(\baselineskip) 15.51797
+...\glue(\baselineskip) 13.51048
 ...\hbox(4.23984+0.0)x417.11752, glue set 370.98518fil
 ....\hbox(0.0+0.0)x24.09
 ....\penalty 0
@@ -264,11 +264,11 @@ Completed box being shipped out [1]
 ....\penalty 10000
 ....\glue(\parfillskip) 0.0 plus 1.0fil
 ....\glue(\rightskip) 0.0
-...\glue(\baselineskip) 22.08249
+...\glue(\baselineskip) 20.075
 ...\hbox(0.0+0.0)x0.0
 ...\glue(\parskip) 0.0
 ...\glue(\parskip) 0.0
-...\glue(\baselineskip) 12.6874
+...\glue(\baselineskip) 10.6799
 ...\hbox(9.3951+2.21626)x417.11752, glue set - 0.03065
 ....\TU/FandolSong(0)/b/n/12.045 关
 ....\glue 0.0 plus 0.61353
@@ -357,7 +357,7 @@ Completed box being shipped out [1]
 ....\TU/FandolSong(0)/m/n/12.045 键
 ....\glue(\rightskip) 0.0
 ...\penalty 300
-...\glue(\baselineskip) 10.59158
+...\glue(\baselineskip) 8.58409
 ...\hbox(9.27464+2.21626)x368.93753, glue set 290.64503fil, shifted 48.18
 ....\TU/FandolSong(0)/m/n/12.045 词
 ....\glue 3.01125 plus 1.50562 minus 1.00374
@@ -382,14 +382,14 @@ Completed box being shipped out [1]
 ...\glue 0.0 plus 1.0fil
 ...\glue 0.0
 ...\glue 0.0 plus 0.0001fil
-..\glue(\baselineskip) 15.85268
-..\hbox(6.6248+0.0)x417.11752
+..\glue(\baselineskip) 16.45493
+..\hbox(6.02255+0.0)x417.11752
 ...\special{color push  Black}
-...\hbox(6.6248+0.0)x417.11752
-....\hbox(6.6248+0.0)x417.11752
-.....\vbox(6.6248+0.0)x417.11752
+...\hbox(6.02255+0.0)x417.11752
+....\hbox(6.02255+0.0)x417.11752
+.....\vbox(6.02255+0.0)x417.11752
 ......\rule(0.0+0.0)x417.11752
-......\glue 6.6248
+......\glue 6.02255
 ......\hbox(0.0+0.0)x417.11752
 .......\hbox(0.0+0.0)x0.0, glue set - 417.11752fil
 ........\vbox(0.0+0.0)x417.11752
@@ -494,7 +494,7 @@ Completed box being shipped out [2]
 ....\special{color pop}
 ..\glue 15.6491
 ..\glue(\lineskip) 0.0
-..\vbox(700.50723+0.0)x417.11752, glue set 472.03236fil
+..\vbox(700.50723+0.0)x417.11752, glue set 486.0833fil
 ...\write-{}
 ...\write-{}
 ...\glue(\topskip) 12.0
@@ -517,7 +517,7 @@ Completed box being shipped out [2]
 ...\glue 19.07124
 ...\glue(\parskip) 0.0
 ...\glue(\parskip) 0.0
-...\glue(\baselineskip) 13.60283
+...\glue(\baselineskip) 11.59534
 ...\hbox(8.22673+2.6258)x417.11752, glue set 0.27924
 ....\hbox(0.0+0.0)x24.09
 ....\TU/texgyretermes(0)/m/n/12.045 Graduate
@@ -545,7 +545,7 @@ Completed box being shipped out [2]
 ....\TU/texgyretermes(0)/m/n/12.045 re-
 ....\glue(\rightskip) 0.0
 ...\penalty 250
-...\glue(\baselineskip) 11.22997
+...\glue(\baselineskip) 9.22247
 ...\hbox(8.22673+2.6258)x417.11752, glue set 0.71335
 ....\TU/texgyretermes(0)/m/n/12.045 flection,
 ....\glue 3.01125 plus 1.88202 minus 0.80298
@@ -578,7 +578,7 @@ Completed box being shipped out [2]
 ....\TU/texgyretermes(0)/m/n/12.045 of
 ....\glue(\rightskip) 0.0
 ...\penalty 150
-...\glue(\baselineskip) 11.22997
+...\glue(\baselineskip) 9.22247
 ...\hbox(8.22673+2.6258)x417.11752, glue set 193.466fil
 ....\TU/texgyretermes(0)/m/n/12.045 application
 ....\glue 3.01125 plus 1.50562 minus 1.00374
@@ -596,18 +596,18 @@ Completed box being shipped out [2]
 ....\glue(\rightskip) 0.0
 ...\glue(\parskip) 0.0
 ...\glue(\parskip) 0.0
-...\glue(\baselineskip) 18.2522
+...\glue(\baselineskip) 16.2447
 ...\hbox(1.2045+0.13248)x417.11752, glue set 380.98253fil
 ....\hbox(0.0+0.0)x24.09
 ....\TU/texgyretermes(0)/m/n/12.045 …
 ....\penalty 10000
 ....\glue(\parfillskip) 0.0 plus 1.0fil
 ....\glue(\rightskip) 0.0
-...\glue(\baselineskip) 21.95001
+...\glue(\baselineskip) 19.94252
 ...\hbox(0.0+0.0)x0.0
 ...\glue(\parskip) 0.0
 ...\glue(\parskip) 0.0
-...\glue(\baselineskip) 13.79553
+...\glue(\baselineskip) 11.78804
 ...\hbox(8.28696+2.6258)x417.11752, glue set - 0.68094
 ....\TU/texgyretermes(0)/b/n/12.045 Key
 ....\glue 3.01125 plus 1.50562 minus 1.00374
@@ -642,7 +642,7 @@ Completed box being shipped out [2]
 ....\TU/texgyretermes(0)/m/n/12.045 Keyword
 ....\glue(\rightskip) 0.0
 ...\penalty 300
-...\glue(\baselineskip) 11.21791
+...\glue(\baselineskip) 9.21042
 ...\hbox(8.23878+2.6258)x338.82504, glue set 208.40184fil, shifted 78.29248
 ....\TU/texgyretermes(0)/m/n/12.045 6;
 ....\glue 3.01125 plus 2.25842 minus 0.66916
@@ -663,15 +663,15 @@ Completed box being shipped out [2]
 ...\glue 0.0 plus 1.0fil
 ...\glue 0.0
 ...\glue 0.0 plus 0.0001fil
-..\glue(\baselineskip) 15.85268
-..\hbox(6.6248+0.0)x417.11752
+..\glue(\baselineskip) 16.45493
+..\hbox(6.02255+0.0)x417.11752
 ...\special{color push  Black}
-...\hbox(6.6248+0.0)x417.11752
+...\hbox(6.02255+0.0)x417.11752
 ....\glue 0.0 plus 1.0fil minus 1.0fil
-....\hbox(6.6248+0.0)x417.11752
-.....\vbox(6.6248+0.0)x417.11752
+....\hbox(6.02255+0.0)x417.11752
+.....\vbox(6.02255+0.0)x417.11752
 ......\rule(0.0+0.0)x417.11752
-......\glue 6.6248
+......\glue 6.02255
 ......\hbox(0.0+0.0)x417.11752
 .......\hbox(0.0+0.0)x0.0, glue set - 417.11752fil
 ........\vbox(0.0+0.0)x417.11752
@@ -777,7 +777,7 @@ Completed box being shipped out [1]
 ....\special{color pop}
 ..\glue 15.6491
 ..\glue(\lineskip) 0.0
-..\vbox(700.50723+0.0)x417.11752, glue set 321.50198fil
+..\vbox(700.50723+0.0)x417.11752, glue set 346.19151fil
 ...\write-{}
 ...\write-{}
 ...\write-{}
@@ -806,11 +806,11 @@ Completed box being shipped out [1]
 ...\penalty 10000
 ...\glue(\parskip) 0.0
 ...\glue(\parskip) 0.0
-...\glue(\baselineskip) 3.51723
-...\hbox(15.45767+6.6248)x417.11752, glue set 335.8138fill
+...\glue(\baselineskip) 2.91498
+...\hbox(14.05243+6.02255)x417.11752, glue set 335.8138fill
 ....\glue(\leftskip) 48.18
 ....\hbox(0.0+0.0)x0.0
-....\rule(15.45767+6.6248)x0.0
+....\rule(14.05243+6.02255)x0.0
 ....\hbox(9.35896+2.21626)x0.0, glue set - 48.18fil
 .....\glue 0.0 plus 1.0fil minus 1.0fil
 .....\hbox(9.35896+2.21626)x48.18
@@ -829,7 +829,7 @@ Completed box being shipped out [1]
 ....\TU/FandolSong(0)/m/n/12.045 言
 ....\kern -0.00017
 ....\kern 0.00017
-....\rule(15.45767+6.6248)x0.0
+....\rule(14.05243+6.02255)x0.0
 ....\kern 0.0
 ....\glue 2.00749
 ....\glue -4.015
@@ -858,10 +858,10 @@ Completed box being shipped out [1]
 ...\glue(\parskip) 0.0
 ...\glue(\parskip) 0.0
 ...\glue(\baselineskip) 0.00002
-...\hbox(15.45767+6.6248)x417.11752, glue set 203.31882fill
+...\hbox(14.05243+6.02255)x417.11752, glue set 203.31882fill
 ....\glue(\leftskip) 60.22499
 ....\hbox(0.0+0.0)x0.0
-....\rule(15.45767+6.6248)x0.0
+....\rule(14.05243+6.02255)x0.0
 ....\hbox(9.35896+2.144)x0.0, glue set - 48.18fil
 .....\glue 0.0 plus 1.0fil minus 1.0fil
 .....\hbox(9.35896+2.144)x48.18
@@ -900,7 +900,7 @@ Completed box being shipped out [1]
 ....\TU/FandolSong(0)/m/n/12.045 析
 ....\kern -0.00017
 ....\kern 0.00017
-....\rule(15.45767+6.6248)x0.0
+....\rule(14.05243+6.02255)x0.0
 ....\kern 0.0
 ....\glue 2.00749
 ....\glue -4.015
@@ -929,10 +929,10 @@ Completed box being shipped out [1]
 ...\glue(\parskip) 0.0
 ...\glue(\parskip) 0.0
 ...\glue(\baselineskip) 0.00002
-...\hbox(15.45767+6.6248)x417.11752, glue set 287.6338fill
+...\hbox(14.05243+6.02255)x417.11752, glue set 287.6338fill
 ....\glue(\leftskip) 48.18
 ....\hbox(0.0+0.0)x0.0
-....\rule(15.45767+6.6248)x0.0
+....\rule(14.05243+6.02255)x0.0
 ....\hbox(4.74573+0.83109)x0.0, glue set - 24.09fil
 .....\glue 0.0 plus 1.0fil minus 1.0fil
 .....\hbox(4.74573+0.83109)x24.09
@@ -960,7 +960,7 @@ Completed box being shipped out [1]
 ....\TU/FandolSong(0)/m/n/12.045 题
 ....\kern -0.00017
 ....\kern 0.00017
-....\rule(15.45767+6.6248)x0.0
+....\rule(14.05243+6.02255)x0.0
 ....\kern 0.0
 ....\glue 2.00749
 ....\glue -4.015
@@ -993,10 +993,10 @@ Completed box being shipped out [1]
 ...\glue(\parskip) 0.0
 ...\glue(\parskip) 0.0
 ...\glue(\baselineskip) 0.00002
-...\hbox(15.45767+6.6248)x417.11752, glue set 311.7238fill
+...\hbox(14.05243+6.02255)x417.11752, glue set 311.7238fill
 ....\glue(\leftskip) 48.18
 ....\hbox(0.0+0.0)x0.0
-....\rule(15.45767+6.6248)x0.0
+....\rule(14.05243+6.02255)x0.0
 ....\hbox(9.35896+2.21626)x0.0, glue set - 48.18fil
 .....\glue 0.0 plus 1.0fil minus 1.0fil
 .....\hbox(9.35896+2.21626)x48.18
@@ -1019,7 +1019,7 @@ Completed box being shipped out [1]
 ....\TU/FandolSong(0)/m/n/12.045 素
 ....\kern -0.00017
 ....\kern 0.00017
-....\rule(15.45767+6.6248)x0.0
+....\rule(14.05243+6.02255)x0.0
 ....\kern 0.0
 ....\glue 2.00749
 ....\glue -4.015
@@ -1048,10 +1048,10 @@ Completed box being shipped out [1]
 ...\glue(\parskip) 0.0
 ...\glue(\parskip) 0.0
 ...\glue(\baselineskip) 0.00002
-...\hbox(15.45767+6.6248)x417.11752, glue set 239.45381fill
+...\hbox(14.05243+6.02255)x417.11752, glue set 239.45381fill
 ....\glue(\leftskip) 60.22499
 ....\hbox(0.0+0.0)x0.0
-....\rule(15.45767+6.6248)x0.0
+....\rule(14.05243+6.02255)x0.0
 ....\hbox(9.35896+2.144)x0.0, glue set - 48.18fil
 .....\glue 0.0 plus 1.0fil minus 1.0fil
 .....\hbox(9.35896+2.144)x48.18
@@ -1086,7 +1086,7 @@ Completed box being shipped out [1]
 ....\TU/FandolSong(0)/m/n/12.045 式
 ....\kern -0.00017
 ....\kern 0.00017
-....\rule(15.45767+6.6248)x0.0
+....\rule(14.05243+6.02255)x0.0
 ....\kern 0.0
 ....\glue 2.00749
 ....\glue -4.015
@@ -1115,10 +1115,10 @@ Completed box being shipped out [1]
 ...\glue(\parskip) 0.0
 ...\glue(\parskip) 0.0
 ...\glue(\baselineskip) 0.00002
-...\hbox(15.45767+6.6248)x417.11752, glue set 335.8138fill
+...\hbox(14.05243+6.02255)x417.11752, glue set 335.8138fill
 ....\glue(\leftskip) 48.18
 ....\hbox(0.0+0.0)x0.0
-....\rule(15.45767+6.6248)x0.0
+....\rule(14.05243+6.02255)x0.0
 ....\hbox(4.74573+0.83109)x0.0, glue set - 24.09fil
 .....\glue 0.0 plus 1.0fil minus 1.0fil
 .....\hbox(4.74573+0.83109)x24.09
@@ -1138,7 +1138,7 @@ Completed box being shipped out [1]
 ....\TU/FandolSong(0)/m/n/12.045 图
 ....\kern -0.00017
 ....\kern 0.00017
-....\rule(15.45767+6.6248)x0.0
+....\rule(14.05243+6.02255)x0.0
 ....\kern 0.0
 ....\glue 2.00749
 ....\glue -4.015
@@ -1167,10 +1167,10 @@ Completed box being shipped out [1]
 ...\glue(\parskip) 0.0
 ...\glue(\parskip) 0.0
 ...\glue(\baselineskip) 0.00002
-...\hbox(15.45767+6.6248)x417.11752, glue set 335.8138fill
+...\hbox(14.05243+6.02255)x417.11752, glue set 335.8138fill
 ....\glue(\leftskip) 48.18
 ....\hbox(0.0+0.0)x0.0
-....\rule(15.45767+6.6248)x0.0
+....\rule(14.05243+6.02255)x0.0
 ....\hbox(7.74493+0.83109)x0.0, glue set - 24.09fil
 .....\glue 0.0 plus 1.0fil minus 1.0fil
 .....\hbox(7.74493+0.83109)x24.09
@@ -1190,7 +1190,7 @@ Completed box being shipped out [1]
 ....\TU/FandolSong(0)/m/n/12.045 格
 ....\kern -0.00017
 ....\kern 0.00017
-....\rule(15.45767+6.6248)x0.0
+....\rule(14.05243+6.02255)x0.0
 ....\kern 0.0
 ....\glue 2.00749
 ....\glue -4.015
@@ -1219,10 +1219,10 @@ Completed box being shipped out [1]
 ...\glue(\parskip) 0.0
 ...\glue(\parskip) 0.0
 ...\glue(\baselineskip) 0.00002
-...\hbox(15.45767+6.6248)x417.11752, glue set 323.7688fill
+...\hbox(14.05243+6.02255)x417.11752, glue set 323.7688fill
 ....\glue(\leftskip) 48.18
 ....\hbox(0.0+0.0)x0.0
-....\rule(15.45767+6.6248)x0.0
+....\rule(14.05243+6.02255)x0.0
 ....\hbox(8.55196+0.83109)x0.0, glue set - 24.09fil
 .....\glue 0.0 plus 1.0fil minus 1.0fil
 .....\hbox(8.55196+0.83109)x24.09
@@ -1244,7 +1244,62 @@ Completed box being shipped out [1]
 ....\TU/FandolSong(0)/m/n/12.045 式
 ....\kern -0.00017
 ....\kern 0.00017
-....\rule(15.45767+6.6248)x0.0
+....\rule(14.05243+6.02255)x0.0
+....\kern 0.0
+....\glue 2.00749
+....\glue -4.015
+....\glue 3.01125
+....\leaders 0.0 plus 1.0fill
+.....\hbox(1.2045+0.13248)x4.015, glue set 1.00375fil
+......\glue 0.0 plus 1.0fil minus 1.0fil
+......\hbox(1.2045+0.13248)x3.01125
+.......\special{color push  Black}
+.......\TU/texgyretermes(0)/m/n/12.045 .
+.......\kern -0.0002
+.......\kern 0.0002
+.......\special{color pop}
+....\kern 0.0
+....\glue 2.00749
+....\TU/texgyretermes(0)/m/n/12.045 6
+....\kern -0.0002
+....\kern 0.0002
+....\penalty 10000
+....\glue(\parfillskip) 0.0 plus 1.0fil
+....\glue(\rightskip) 0.0
+...\penalty 10000
+...\glue 12.045
+...\glue -18.045
+...\penalty -300
+...\glue 6.0
+...\glue 12.045
+...\glue 0.0 plus 0.1
+...\penalty 10000
+...\glue(\parskip) 0.0
+...\glue(\parskip) 0.0
+...\glue(\baselineskip) 0.00002
+...\hbox(14.05243+6.02255)x417.11752, glue set 335.8138fill
+....\glue(\leftskip) 48.18
+....\hbox(0.0+0.0)x0.0
+....\rule(14.05243+6.02255)x0.0
+....\hbox(9.35896+2.21626)x0.0, glue set - 48.18fil
+.....\glue 0.0 plus 1.0fil minus 1.0fil
+.....\hbox(9.35896+2.21626)x48.18
+......\special{color push  Black}
+......\TU/FandolSong(0)/m/n/12.045 第
+......\glue 0.0 plus 0.61353
+......\TU/FandolSong(0)/m/n/12.045 三
+......\glue 0.0 plus 0.61353
+......\TU/FandolSong(0)/m/n/12.045 章
+......\kern -0.00017
+......\kern 0.00017
+......\glue 12.045
+......\special{color pop}
+....\TU/FandolSong(0)/m/n/12.045 引
+....\glue 0.0 plus 0.61353
+....\TU/FandolSong(0)/m/n/12.045 用
+....\kern -0.00017
+....\kern 0.00017
+....\rule(14.05243+6.02255)x0.0
 ....\kern 0.0
 ....\glue 2.00749
 ....\glue -4.015
@@ -1269,7 +1324,7 @@ Completed box being shipped out [1]
 ...\penalty 10000
 ...\glue 12.045
 ...\glue -18.045
-...\penalty -300
+...\penalty 0
 ...\glue 6.0
 ...\glue 12.045
 ...\glue 0.0 plus 0.1
@@ -1277,29 +1332,19 @@ Completed box being shipped out [1]
 ...\glue(\parskip) 0.0
 ...\glue(\parskip) 0.0
 ...\glue(\baselineskip) 0.00002
-...\hbox(15.45767+6.6248)x417.11752, glue set 335.8138fill
-....\glue(\leftskip) 48.18
+...\hbox(14.05243+6.02255)x417.11752, glue set 359.9038fill
 ....\hbox(0.0+0.0)x0.0
-....\rule(15.45767+6.6248)x0.0
-....\hbox(9.35896+2.21626)x0.0, glue set - 48.18fil
-.....\glue 0.0 plus 1.0fil minus 1.0fil
-.....\hbox(9.35896+2.21626)x48.18
-......\special{color push  Black}
-......\TU/FandolSong(0)/m/n/12.045 第
-......\glue 0.0 plus 0.61353
-......\TU/FandolSong(0)/m/n/12.045 三
-......\glue 0.0 plus 0.61353
-......\TU/FandolSong(0)/m/n/12.045 章
-......\kern -0.00017
-......\kern 0.00017
-......\glue 12.045
-......\special{color pop}
-....\TU/FandolSong(0)/m/n/12.045 引
+....\rule(14.05243+6.02255)x0.0
+....\TU/FandolSong(0)/m/n/12.045 参
 ....\glue 0.0 plus 0.61353
-....\TU/FandolSong(0)/m/n/12.045 用
+....\TU/FandolSong(0)/m/n/12.045 考
+....\glue 0.0 plus 0.61353
+....\TU/FandolSong(0)/m/n/12.045 文
+....\glue 0.0 plus 0.61353
+....\TU/FandolSong(0)/m/n/12.045 献
 ....\kern -0.00017
 ....\kern 0.00017
-....\rule(15.45767+6.6248)x0.0
+....\rule(14.05243+6.02255)x0.0
 ....\kern 0.0
 ....\glue 2.00749
 ....\glue -4.015
@@ -1322,29 +1367,39 @@ Completed box being shipped out [1]
 ....\glue(\parfillskip) 0.0 plus 1.0fil
 ....\glue(\rightskip) 0.0
 ...\penalty 10000
-...\glue 12.045
-...\glue -18.045
 ...\penalty 0
-...\glue 6.0
-...\glue 12.045
 ...\glue 0.0 plus 0.1
 ...\penalty 10000
 ...\glue(\parskip) 0.0
 ...\glue(\parskip) 0.0
 ...\glue(\baselineskip) 0.00002
-...\hbox(15.45767+6.6248)x417.11752, glue set 359.9038fill
+...\hbox(14.05243+6.02255)x417.11752, glue set 312.06107fill
+....\glue(\leftskip) 47.84273
 ....\hbox(0.0+0.0)x0.0
-....\rule(15.45767+6.6248)x0.0
-....\TU/FandolSong(0)/m/n/12.045 参
+....\rule(14.05243+6.02255)x0.0
+....\hbox(9.14215+1.99945)x0.0, glue set - 47.84273fil
+.....\glue 0.0 plus 1.0fil minus 1.0fil
+.....\hbox(9.14215+1.99945)x47.84273
+......\special{color push  Black}
+......\TU/FandolSong(0)/m/n/12.045 附
+......\glue 0.0 plus 0.61353
+......\TU/FandolSong(0)/m/n/12.045 录
+......\glue 3.01125 plus 1.5041 minus 1.00473
+......\TU/texgyretermes(0)/m/n/12.045 A
+......\kern -0.0002
+......\kern 0.0002
+......\glue 12.045
+......\special{color pop}
+....\TU/FandolSong(0)/m/n/12.045 附
 ....\glue 0.0 plus 0.61353
-....\TU/FandolSong(0)/m/n/12.045 考
+....\TU/FandolSong(0)/m/n/12.045 录
 ....\glue 0.0 plus 0.61353
-....\TU/FandolSong(0)/m/n/12.045 文
+....\TU/FandolSong(0)/m/n/12.045 章
 ....\glue 0.0 plus 0.61353
-....\TU/FandolSong(0)/m/n/12.045 献
+....\TU/FandolSong(0)/m/n/12.045 节
 ....\kern -0.00017
 ....\kern 0.00017
-....\rule(15.45767+6.6248)x0.0
+....\rule(14.05243+6.02255)x0.0
 ....\kern 0.0
 ....\glue 2.00749
 ....\glue -4.015
@@ -1373,33 +1428,15 @@ Completed box being shipped out [1]
 ...\glue(\parskip) 0.0
 ...\glue(\parskip) 0.0
 ...\glue(\baselineskip) 0.00002
-...\hbox(15.45767+6.6248)x417.11752, glue set 306.03857fill
-....\glue(\leftskip) 47.84273
+...\hbox(14.05243+6.02255)x417.11752, glue set 377.9713fill
 ....\hbox(0.0+0.0)x0.0
-....\rule(15.45767+6.6248)x0.0
-....\hbox(9.14215+1.99945)x0.0, glue set - 47.84273fil
-.....\glue 0.0 plus 1.0fil minus 1.0fil
-.....\hbox(9.14215+1.99945)x47.84273
-......\special{color push  Black}
-......\TU/FandolSong(0)/m/n/12.045 附
-......\glue 0.0 plus 0.61353
-......\TU/FandolSong(0)/m/n/12.045 录
-......\glue 3.01125 plus 1.5041 minus 1.00473
-......\TU/texgyretermes(0)/m/n/12.045 A
-......\kern -0.0002
-......\kern 0.0002
-......\glue 12.045
-......\special{color pop}
-....\TU/FandolSong(0)/m/n/12.045 附
+....\rule(14.05243+6.02255)x0.0
+....\TU/FandolSong(0)/m/n/12.045 致
 ....\glue 0.0 plus 0.61353
-....\TU/FandolSong(0)/m/n/12.045 录
-....\glue 0.0 plus 0.61353
-....\TU/FandolSong(0)/m/n/12.045 章
-....\glue 0.0 plus 0.61353
-....\TU/FandolSong(0)/m/n/12.045 节
+....\TU/FandolSong(0)/m/n/12.045 谢
 ....\kern -0.00017
 ....\kern 0.00017
-....\rule(15.45767+6.6248)x0.0
+....\rule(14.05243+6.02255)x0.0
 ....\kern 0.0
 ....\glue 2.00749
 ....\glue -4.015
@@ -1422,54 +1459,17 @@ Completed box being shipped out [1]
 ....\glue(\parfillskip) 0.0 plus 1.0fil
 ....\glue(\rightskip) 0.0
 ...\penalty 10000
-...\penalty 0
-...\glue 0.0 plus 0.1
-...\penalty 10000
-...\glue(\parskip) 0.0
-...\glue(\parskip) 0.0
-...\glue(\baselineskip) 0.00002
-...\hbox(15.45767+6.6248)x417.11752, glue set 377.9713fill
-....\hbox(0.0+0.0)x0.0
-....\rule(15.45767+6.6248)x0.0
-....\TU/FandolSong(0)/m/n/12.045 致
-....\glue 0.0 plus 0.61353
-....\TU/FandolSong(0)/m/n/12.045 谢
-....\kern -0.00017
-....\kern 0.00017
-....\rule(15.45767+6.6248)x0.0
-....\kern 0.0
-....\glue 2.00749
-....\glue -4.015
-....\glue 3.01125
-....\leaders 0.0 plus 1.0fill
-.....\hbox(1.2045+0.13248)x4.015, glue set 1.00375fil
-......\glue 0.0 plus 1.0fil minus 1.0fil
-......\hbox(1.2045+0.13248)x3.01125
-.......\special{color push  Black}
-.......\TU/texgyretermes(0)/m/n/12.045 .
-.......\kern -0.0002
-.......\kern 0.0002
-.......\special{color pop}
-....\kern 0.0
-....\glue 2.00749
-....\TU/texgyretermes(0)/m/n/12.045 11
-....\kern -0.0002
-....\kern 0.0002
-....\penalty 10000
-....\glue(\parfillskip) 0.0 plus 1.0fil
-....\glue(\rightskip) 0.0
-...\penalty 10000
 ...\glue 0.0 plus 1.0fil
 ...\glue 0.0
 ...\glue 0.0 plus 0.0001fil
-..\glue(\baselineskip) 7.63202
-..\hbox(14.84546+3.5232)x417.11752
+..\glue(\baselineskip) 8.23427
+..\hbox(14.24321+3.5232)x417.11752
 ...\special{color push  Black}
-...\hbox(14.84546+3.5232)x417.11752
-....\hbox(14.84546+3.5232)x417.11752
-.....\vbox(14.84546+3.5232)x417.11752
+...\hbox(14.24321+3.5232)x417.11752
+....\hbox(14.24321+3.5232)x417.11752
+.....\vbox(14.24321+3.5232)x417.11752
 ......\rule(0.0+0.0)x417.11752
-......\glue 6.6248
+......\glue 6.02255
 ......\hbox(8.22066+3.5232)x417.11752
 .......\hbox(0.0+0.0)x0.0, glue set - 417.11752fil
 ........\vbox(0.0+0.0)x417.11752
@@ -1582,7 +1582,7 @@ Completed box being shipped out [2]
 ....\special{color pop}
 ..\glue 15.6491
 ..\glue(\lineskip) 0.0
-..\vbox(700.50723+0.0)x417.11752, glue set 578.43443fil
+..\vbox(700.50723+0.0)x417.11752, glue set 583.05118fil
 ...\write-{}
 ...\write-{}
 ...\glue(\topskip) 12.0
@@ -1619,11 +1619,11 @@ Completed box being shipped out [2]
 ...\penalty 10000
 ...\glue(\parskip) 0.0
 ...\glue(\parskip) 0.0
-...\glue(\baselineskip) 3.33655
-...\hbox(15.45767+6.6248)x417.11752, glue set 269.56631fill
+...\glue(\baselineskip) 2.7343
+...\hbox(14.05243+6.02255)x417.11752, glue set 269.56631fill
 ....\glue(\leftskip) 42.15749
 ....\hbox(0.0+0.0)x0.0
-....\rule(15.45767+6.6248)x0.0
+....\rule(14.05243+6.02255)x0.0
 ....\hbox(8.84103+1.73447)x0.0, glue set - 42.15749fil
 .....\glue 0.0 plus 1.0fil minus 1.0fil
 .....\hbox(8.84103+1.73447)x42.15749
@@ -1655,7 +1655,7 @@ Completed box being shipped out [2]
 ....\TU/FandolSong(0)/m/n/12.045 方
 ....\kern -0.00017
 ....\kern 0.00017
-....\rule(15.45767+6.6248)x0.0
+....\rule(14.05243+6.02255)x0.0
 ....\kern 0.0
 ....\glue 2.00749
 ....\glue -4.015
@@ -1684,10 +1684,10 @@ Completed box being shipped out [2]
 ...\glue(\parskip) 0.0
 ...\glue(\parskip) 0.0
 ...\glue(\baselineskip) 0.00002
-...\hbox(15.45767+6.6248)x417.11752, glue set 269.56631fill
+...\hbox(14.05243+6.02255)x417.11752, glue set 269.56631fill
 ....\glue(\leftskip) 42.15749
 ....\hbox(0.0+0.0)x0.0
-....\rule(15.45767+6.6248)x0.0
+....\rule(14.05243+6.02255)x0.0
 ....\hbox(9.31079+2.09581)x0.0, glue set - 42.15749fil
 .....\glue 0.0 plus 1.0fil minus 1.0fil
 .....\hbox(9.31079+2.09581)x42.15749
@@ -1719,7 +1719,7 @@ Completed box being shipped out [2]
 ....\TU/FandolSong(0)/m/n/12.045 方
 ....\kern -0.00017
 ....\kern 0.00017
-....\rule(15.45767+6.6248)x0.0
+....\rule(14.05243+6.02255)x0.0
 ....\kern 0.0
 ....\glue 2.00749
 ....\glue -4.015
@@ -1745,15 +1745,15 @@ Completed box being shipped out [2]
 ...\glue 0.0 plus 1.0fil
 ...\glue 0.0
 ...\glue 0.0 plus 0.0001fil
-..\glue(\baselineskip) 7.63202
-..\hbox(14.84546+3.5232)x417.11752
+..\glue(\baselineskip) 8.23427
+..\hbox(14.24321+3.5232)x417.11752
 ...\special{color push  Black}
-...\hbox(14.84546+3.5232)x417.11752
+...\hbox(14.24321+3.5232)x417.11752
 ....\glue 0.0 plus 1.0fil minus 1.0fil
-....\hbox(14.84546+3.5232)x417.11752
-.....\vbox(14.84546+3.5232)x417.11752
+....\hbox(14.24321+3.5232)x417.11752
+.....\vbox(14.24321+3.5232)x417.11752
 ......\rule(0.0+0.0)x417.11752
-......\glue 6.6248
+......\glue 6.02255
 ......\hbox(8.22066+3.5232)x417.11752
 .......\hbox(0.0+0.0)x0.0, glue set - 417.11752fil
 ........\vbox(0.0+0.0)x417.11752
@@ -1861,7 +1861,7 @@ Completed box being shipped out [3]
 ....\special{color pop}
 ..\glue 15.6491
 ..\glue(\lineskip) 0.0
-..\vbox(700.50723+0.0)x417.11752, glue set 607.0062fil
+..\vbox(700.50723+0.0)x417.11752, glue set 609.01347fil
 ...\write-{}
 ...\write-{}
 ...\glue(\topskip) 12.0
@@ -1890,7 +1890,7 @@ Completed box being shipped out [3]
 ...\glue 19.07124
 ...\glue(\parskip) 0.0
 ...\glue(\parskip) 0.0
-...\glue(\baselineskip) 10.96498
+...\glue(\baselineskip) 8.95749
 ...\hbox(7.97379+0.13248)x417.11752, glue set 339.3992fil
 ....\hbox(0.0+0.0)x24.09
 ....\TU/texgyretermes(0)/m/n/12.045 Notations.
@@ -1901,14 +1901,14 @@ Completed box being shipped out [3]
 ...\glue 0.0 plus 1.0fil
 ...\glue 0.0
 ...\glue 0.0 plus 0.0001fil
-..\glue(\baselineskip) 7.63202
-..\hbox(14.84546+3.5232)x417.11752
+..\glue(\baselineskip) 8.23427
+..\hbox(14.24321+3.5232)x417.11752
 ...\special{color push  Black}
-...\hbox(14.84546+3.5232)x417.11752
-....\hbox(14.84546+3.5232)x417.11752
-.....\vbox(14.84546+3.5232)x417.11752
+...\hbox(14.24321+3.5232)x417.11752
+....\hbox(14.24321+3.5232)x417.11752
+.....\vbox(14.24321+3.5232)x417.11752
 ......\rule(0.0+0.0)x417.11752
-......\glue 6.6248
+......\glue 6.02255
 ......\hbox(8.22066+3.5232)x417.11752
 .......\hbox(0.0+0.0)x0.0, glue set - 417.11752fil
 ........\vbox(0.0+0.0)x417.11752
@@ -2018,7 +2018,7 @@ Completed box being shipped out [4]
 ....\special{color pop}
 ..\glue 15.6491
 ..\glue(\lineskip) 0.0
-..\vbox(700.50723+0.0)x417.11752, glue set 242.33476fil
+..\vbox(700.50723+0.0)x417.11752, glue set 268.42937fil
 ...\write-{}
 ...\write-{}
 ...\write2{\@writefile{toc}{\protect \addvspace {12bp}}}
@@ -2054,7 +2054,7 @@ Completed box being shipped out [4]
 ...\glue 19.07124
 ...\glue(\parskip) 0.0
 ...\glue(\parskip) 0.0
-...\glue(\baselineskip) 9.84479
+...\glue(\baselineskip) 7.8373
 ...\hbox(9.3951+2.32468)x417.11752, glue set 0.41225
 ....\hbox(0.0+0.0)x24.09
 ....\TU/FandolSong(0)/m/n/12.045 研
@@ -2124,7 +2124,7 @@ Completed box being shipped out [4]
 ....\TU/FandolSong(0)/m/n/12.045 依
 ....\glue(\rightskip) 0.0
 ...\penalty 10000
-...\glue(\baselineskip) 10.36272
+...\glue(\baselineskip) 8.35522
 ...\hbox(9.3951+2.32468)x417.11752, glue set - 0.2467
 ....\TU/FandolSong(0)/m/n/12.045 据
 ....\penalty 10000
@@ -2202,7 +2202,7 @@ Completed box being shipped out [4]
 ....\glue 0.0 plus 0.61353
 ....\TU/FandolSong(0)/m/n/12.045 提
 ....\glue(\rightskip) 0.0
-...\glue(\baselineskip) 10.35066
+...\glue(\baselineskip) 8.34317
 ...\hbox(9.40715+2.32468)x417.11752, glue set 0.38647
 ....\TU/FandolSong(0)/m/n/12.045 高
 ....\glue 0.0 plus 0.61353
@@ -2274,7 +2274,7 @@ Completed box being shipped out [4]
 ....\glue 0.0 plus 0.61353
 ....\TU/FandolSong(0)/m/n/12.045 同
 ....\glue(\rightskip) 0.0
-...\glue(\baselineskip) 10.36272
+...\glue(\baselineskip) 8.35522
 ...\hbox(9.3951+2.32468)x417.11752, glue set - 0.37006
 ....\TU/FandolSong(0)/m/n/12.045 努
 ....\glue 0.0 plus 0.61353
@@ -2351,7 +2351,7 @@ Completed box being shipped out [4]
 ....\TU/FandolSong(0)/m/n/12.045 问
 ....\glue(\rightskip) 0.0
 ...\penalty 150
-...\glue(\baselineskip) 10.31453
+...\glue(\baselineskip) 8.30704
 ...\hbox(9.44328+2.32468)x417.11752, glue set 135.79454fil
 ....\TU/FandolSong(0)/m/n/12.045 题
 ....\glue 0.0 plus 0.61353
@@ -2461,7 +2461,7 @@ Completed box being shipped out [4]
 ...\glue 6.02249
 ...\glue(\parskip) 0.0
 ...\glue(\parskip) 0.0
-...\glue(\baselineskip) 10.02245
+...\glue(\baselineskip) 8.01495
 ...\hbox(9.3951+2.32468)x417.11752, glue set 0.41225
 ....\hbox(0.0+0.0)x24.09
 ....\TU/FandolSong(0)/m/n/12.045 从
@@ -2531,7 +2531,7 @@ Completed box being shipped out [4]
 ....\TU/FandolSong(0)/m/n/12.045 这
 ....\glue(\rightskip) 0.0
 ...\penalty 10150
-...\glue(\baselineskip) 10.41089
+...\glue(\baselineskip) 8.4034
 ...\hbox(9.34692+2.16809)x417.11752, glue set 220.10953fil
 ....\TU/FandolSong(0)/m/n/12.045 两
 ....\glue 0.0 plus 0.61353
@@ -2613,7 +2613,7 @@ Completed box being shipped out [4]
 ...\glue 6.02249
 ...\glue(\parskip) 0.0
 ...\glue(\parskip) 0.0
-...\glue(\baselineskip) 10.31453
+...\glue(\baselineskip) 8.30704
 ...\hbox(9.40715+2.32468)x417.11752, glue set 0.42645
 ....\hbox(0.0+0.0)x24.09
 ....\TU/FandolSong(0)/m/n/12.045 文
@@ -2685,7 +2685,7 @@ Completed box being shipped out [4]
 ....\TU/FandolSong(0)/m/n/12.045 何
 ....\glue(\rightskip) 0.0
 ...\penalty 10000
-...\glue(\baselineskip) 10.35066
+...\glue(\baselineskip) 8.34317
 ...\hbox(9.40715+2.32468)x417.11752, glue set 0.17856
 ....\TU/FandolSong(0)/m/n/12.045 写
 ....\penalty 10000
@@ -2762,7 +2762,7 @@ Completed box being shipped out [4]
 ....\TU/FandolSong(0)/m/n/12.045 、
 ....\rule(0.0+0.0)x-7.85333
 ....\glue(\rightskip) 0.0
-...\glue(\baselineskip) 10.33862
+...\glue(\baselineskip) 8.33113
 ...\hbox(9.41919+2.32468)x417.11752, glue set - 0.33904
 ....\TU/FandolSong(0)/m/n/12.045 缩
 ....\glue 0.0 plus 0.61353
@@ -2845,7 +2845,7 @@ Completed box being shipped out [4]
 ....\TU/FandolSong(0)/m/n/12.045 ，
 ....\rule(0.0+0.0)x-8.33514
 ....\glue(\rightskip) 0.0
-...\glue(\baselineskip) 10.38681
+...\glue(\baselineskip) 8.37932
 ...\hbox(9.371+2.32468)x417.11752, glue set 0.1969
 ....\TU/FandolSong(0)/m/n/12.045 方
 ....\glue 0.0 plus 0.61353
@@ -2920,7 +2920,7 @@ Completed box being shipped out [4]
 ....\TU/FandolSong(0)/m/n/12.045 ；
 ....\rule(0.0+0.0)x-8.32309
 ....\glue(\rightskip) 0.0
-...\glue(\baselineskip) 10.36272
+...\glue(\baselineskip) 8.35522
 ...\hbox(9.3951+2.32468)x417.11752, glue set - 0.37006
 ....\TU/FandolSong(0)/m/n/12.045 有
 ....\glue 0.0 plus 0.61353
@@ -2997,7 +2997,7 @@ Completed box being shipped out [4]
 ....\TU/FandolSong(0)/m/n/12.045 段
 ....\glue(\rightskip) 0.0
 ...\penalty 150
-...\glue(\baselineskip) 10.33862
+...\glue(\baselineskip) 8.33113
 ...\hbox(9.41919+1.98741)x417.11752, glue set 352.6045fil
 ....\TU/FandolSong(0)/m/n/12.045 的
 ....\glue 0.0 plus 0.61353
@@ -3021,15 +3021,15 @@ Completed box being shipped out [4]
 ...\glue 0.0 plus 1.0fil
 ...\glue 0.0
 ...\glue 0.0 plus 0.0001fil
-..\glue(\baselineskip) 7.63202
-..\hbox(14.84546+3.5232)x417.11752
+..\glue(\baselineskip) 8.23427
+..\hbox(14.24321+3.5232)x417.11752
 ...\special{color push  Black}
-...\hbox(14.84546+3.5232)x417.11752
+...\hbox(14.24321+3.5232)x417.11752
 ....\glue 0.0 plus 1.0fil minus 1.0fil
-....\hbox(14.84546+3.5232)x417.11752
-.....\vbox(14.84546+3.5232)x417.11752
+....\hbox(14.24321+3.5232)x417.11752
+.....\vbox(14.24321+3.5232)x417.11752
 ......\rule(0.0+0.0)x417.11752
-......\glue 6.6248
+......\glue 6.02255
 ......\hbox(8.22066+3.5232)x417.11752
 .......\hbox(0.0+0.0)x0.0, glue set - 417.11752fil
 ........\vbox(0.0+0.0)x417.11752
@@ -3164,7 +3164,7 @@ Completed box being shipped out [5]
 ....\special{color pop}
 ..\glue 15.6491
 ..\glue(\lineskip) 0.0
-..\vbox(700.50723+0.0)x417.11752, glue set >20000.0fil
+..\vbox(700.50723+0.0)x417.11752, glue set 6.00505fil
 ...\write-{}
 ...\write2{\@writefile{toc}{\protect \addvspace {12bp}}}
 ...\write2{\pp@pagectr{footnote}{2}{\theabspage }{\thepage }}
@@ -3245,7 +3245,7 @@ Completed box being shipped out [5]
 ...\glue 6.02249
 ...\glue(\parskip) 0.0
 ...\glue(\parskip) 0.0
-...\glue(\baselineskip) 9.94115
+...\glue(\baselineskip) 7.93365
 ...\hbox(9.43123+2.32468)x417.11752, glue set - 0.2467
 ....\hbox(0.0+0.0)x24.09
 ....\TU/FandolSong(0)/m/n/12.045 图
@@ -3321,7 +3321,7 @@ Completed box being shipped out [5]
 ....\TU/FandolSong(0)/m/n/12.045 序
 ....\glue(\rightskip) 0.0
 ...\penalty 10000
-...\glue(\baselineskip) 10.32658
+...\glue(\baselineskip) 8.31909
 ...\hbox(9.43123+2.32468)x417.11752, glue set - 0.24803
 ....\TU/FandolSong(0)/m/n/12.045 号
 ....\penalty 10000
@@ -3407,7 +3407,7 @@ Completed box being shipped out [5]
 ....\TU/FandolSong(0)/m/n/12.045 连
 ....\glue(\rightskip) 0.0
 ...\penalty 150
-...\glue(\baselineskip) 10.12181
+...\glue(\baselineskip) 8.11432
 ...\hbox(9.636+2.40898)x417.11752, glue set 156.87334fil
 ....\TU/FandolSong(0)/m/n/12.045 接
 ....\penalty 10000
@@ -3529,7 +3529,7 @@ Completed box being shipped out [5]
 ...\glue 6.02249
 ...\glue(\parskip) 0.0
 ...\glue(\parskip) 0.0
-...\glue(\baselineskip) 10.44101
+...\glue(\baselineskip) 8.43352
 ...\hbox(9.40715+2.15604)x417.11752, glue set 220.10953fil
 ....\hbox(0.0+0.0)x24.09
 ....\TU/FandolSong(0)/m/n/12.045 插
@@ -3576,9 +3576,9 @@ Completed box being shipped out [5]
 ...\penalty 0
 ...\glue 10.03749
 ...\glue 0.0
-...\vbox(225.50859+0.0)x417.11752
+...\vbox(217.47862+0.0)x417.11752
 ....\special{color push  Black}
-....\vbox(225.50859+0.0)x417.11752
+....\vbox(217.47862+0.0)x417.11752
 .....\hbox(125.13368+0.0)x417.11752, glue set 145.99051fil
 ......\glue(\leftskip) 0.0 plus 1.0fil
 ......\hbox(0.0+0.0)x0.0
@@ -3604,11 +3604,11 @@ Completed box being shipped out [5]
 .....\glue 6.02249
 .....\glue(\parskip) 0.0
 .....\glue(\parskip) 0.0
-.....\hbox(15.45767+6.6248)x417.11752
+.....\hbox(14.05243+6.02255)x417.11752
 ......\hbox(0.0+0.0)x0.0
 ......\glue 0.0
-......\vbox(15.45767+6.6248)x417.11752
-.......\hbox(15.45767+6.6248)x417.11752, glue set 139.30003fil
+......\vbox(14.05243+6.02255)x417.11752
+.......\hbox(14.05243+6.02255)x417.11752, glue set 139.30003fil
 ........\glue(\leftskip) 0.0 plus 1.0fil
 ........\hbox(0.0+0.0)x0.0
 ........\TU/FandolSong(0)/m/n/12.045 图
@@ -3620,7 +3620,7 @@ Completed box being shipped out [5]
 ........\kern -0.0002
 ........\kern 0.0002
 ........\glue 12.045
-........\rule(15.45767+*)x0.0
+........\rule(14.05243+*)x0.0
 ........\penalty 10000
 ........\glue 0.0
 ........\TU/FandolSong(0)/m/n/12.045 图
@@ -3641,7 +3641,7 @@ Completed box being shipped out [5]
 ........\kern -0.00017
 ........\kern 0.00017
 ........\penalty 10000
-........\rule(0.0+6.6248)x0.0
+........\rule(0.0+6.02255)x0.0
 ........\penalty 10000
 ........\glue(\parfillskip) 0.0
 ........\glue(\rightskip) 0.0 plus 1.0fil
@@ -3657,14 +3657,14 @@ Completed box being shipped out [5]
 .....\glue 6.02249
 .....\glue(\parskip) 0.0
 .....\glue(\parskip) 0.0
-.....\hbox(59.62265+6.6248)x417.11752
+.....\hbox(54.20242+6.02255)x417.11752
 ......\hbox(0.0+0.0)x0.0
 ......\glue 21.07874
-......\vbox(59.62265+6.6248)x396.03879
-.......\hbox(15.45767+2.32468)x396.03879, glue set - 0.08005
+......\vbox(54.20242+6.02255)x396.03879
+.......\hbox(14.05243+2.32468)x396.03879, glue set - 0.08005
 ........\glue(\leftskip) 0.0 plus 1.0fil
 ........\hbox(0.0+0.0)x0.0
-........\rule(15.45767+*)x0.0
+........\rule(14.05243+*)x0.0
 ........\penalty 10000
 ........\glue 0.0
 ........\TU/FandolSong(0)/m/n/12.045 若
@@ -3740,7 +3740,7 @@ Completed box being shipped out [5]
 ........\TU/FandolSong(0)/m/n/12.045 标
 ........\glue(\rightskip) 0.0 plus -1.0fil
 .......\penalty 10000
-.......\glue(\baselineskip) 10.35066
+.......\glue(\baselineskip) 8.34317
 .......\hbox(9.40715+2.32468)x396.03879, glue set - 0.12006
 ........\glue(\leftskip) 0.0 plus 1.0fil
 ........\TU/FandolSong(0)/m/n/12.045 点
@@ -3814,8 +3814,8 @@ Completed box being shipped out [5]
 ........\TU/FandolSong(0)/m/n/12.045 注
 ........\glue(\rightskip) 0.0 plus -1.0fil
 .......\penalty 150
-.......\glue(\baselineskip) 10.36272
-.......\hbox(9.3951+6.6248)x396.03879, glue set 27.2454fil
+.......\glue(\baselineskip) 8.35522
+.......\hbox(9.3951+6.02255)x396.03879, glue set 27.2454fil
 ........\glue(\leftskip) 0.0 plus 1.0fil
 ........\TU/FandolSong(0)/m/n/12.045 文
 ........\glue 0.0 plus 0.75479
@@ -3882,7 +3882,7 @@ Completed box being shipped out [5]
 ........\kern -0.18753
 ........\kern 0.18753
 ........\penalty 10000
-........\rule(0.0+6.6248)x0.0
+........\rule(0.0+6.02255)x0.0
 ........\penalty 10000
 ........\glue(\parfillskip) 0.0 plus 2.0fil
 ........\glue(\rightskip) 0.0 plus -1.0fil
@@ -3994,7 +3994,7 @@ Completed box being shipped out [5]
 ...\glue 6.02249
 ...\glue(\parskip) 0.0
 ...\glue(\parskip) 0.0
-...\glue(\baselineskip) 10.1459
+...\glue(\baselineskip) 8.13841
 ...\hbox(9.40715+2.15604)x417.11752, glue set 220.10953fil
 ....\hbox(0.0+0.0)x24.09
 ....\TU/FandolSong(0)/m/n/12.045 表
@@ -4041,19 +4041,19 @@ Completed box being shipped out [5]
 ...\penalty 0
 ...\glue 10.03749
 ...\glue 0.0
-...\vbox(124.22385+0.0)x417.11752
+...\vbox(122.21635+0.0)x417.11752
 ....\special{color push  Black}
-....\vbox(124.22385+0.0)x417.11752
+....\vbox(122.21635+0.0)x417.11752
 .....\write2{\@writefile{lot}{\protect \contentsline {table}{\protect \numberline {2.1}{\ignorespaces 表题置于表的上方}}{\thepage }{}\protected@file@percent }}
 .....\special{color push  Black}
 .....\glue 0.0
 .....\glue(\parskip) 0.0
 .....\glue(\parskip) 0.0
-.....\hbox(15.45767+6.6248)x417.11752
+.....\hbox(14.05243+6.02255)x417.11752
 ......\hbox(0.0+0.0)x0.0
 ......\glue 0.0
-......\vbox(15.45767+6.6248)x417.11752
-.......\hbox(15.45767+6.6248)x417.11752, glue set 139.30003fil
+......\vbox(14.05243+6.02255)x417.11752
+.......\hbox(14.05243+6.02255)x417.11752, glue set 139.30003fil
 ........\glue(\leftskip) 0.0 plus 1.0fil
 ........\hbox(0.0+0.0)x0.0
 ........\TU/FandolSong(0)/m/n/12.045 表
@@ -4065,7 +4065,7 @@ Completed box being shipped out [5]
 ........\kern -0.0002
 ........\kern 0.0002
 ........\glue 12.045
-........\rule(15.45767+*)x0.0
+........\rule(14.05243+*)x0.0
 ........\penalty 10000
 ........\glue 0.0
 ........\TU/FandolSong(0)/m/n/12.045 表
@@ -4086,7 +4086,7 @@ Completed box being shipped out [5]
 ........\kern -0.00017
 ........\kern 0.00017
 ........\penalty 10000
-........\rule(0.0+6.6248)x0.0
+........\rule(0.0+6.02255)x0.0
 ........\penalty 10000
 ........\glue(\parfillskip) 0.0
 ........\glue(\rightskip) 0.0 plus 1.0fil
@@ -4346,16 +4346,87 @@ Completed box being shipped out [5]
 ......\glue(\rightskip) 0.0 plus 1.0fil
 .....\glue 0.0
 ....\special{color pop}
+...\penalty 0
+...\penalty 10000
+...\glue 10.03749
+...\glue(\parskip) 0.0
+...\glue(\parskip) 0.0
+...\hbox(9.40715+2.32468)x417.11752, glue set 75.56955fil
+....\hbox(0.0+0.0)x24.09
+....\TU/FandolSong(0)/m/n/12.045 不
+....\glue 0.0 plus 0.61353
+....\TU/FandolSong(0)/m/n/12.045 宜
+....\glue 0.0 plus 0.61353
+....\TU/FandolSong(0)/m/n/12.045 将
+....\glue 0.0 plus 0.61353
+....\TU/FandolSong(0)/m/n/12.045 多
+....\glue 0.0 plus 0.61353
+....\TU/FandolSong(0)/m/n/12.045 个
+....\glue 0.0 plus 0.61353
+....\TU/FandolSong(0)/m/n/12.045 表
+....\glue 0.0 plus 0.61353
+....\TU/FandolSong(0)/m/n/12.045 格
+....\glue 0.0 plus 0.61353
+....\TU/FandolSong(0)/m/n/12.045 连
+....\glue 0.0 plus 0.61353
+....\TU/FandolSong(0)/m/n/12.045 续
+....\glue 0.0 plus 0.61353
+....\TU/FandolSong(0)/m/n/12.045 排
+....\glue 0.0 plus 0.61353
+....\TU/FandolSong(0)/m/n/12.045 版
+....\penalty 10000
+....\TU/FandolSong(0)/m/n/12.045 ，
+....\rule(0.0+0.0)x-8.33514
+....\glue 8.33514 minus 6.0225
+....\glue 0.0 plus 0.61353
+....\TU/FandolSong(0)/m/n/12.045 表
+....\glue 0.0 plus 0.61353
+....\TU/FandolSong(0)/m/n/12.045 格
+....\glue 0.0 plus 0.61353
+....\TU/FandolSong(0)/m/n/12.045 与
+....\glue 0.0 plus 0.61353
+....\TU/FandolSong(0)/m/n/12.045 文
+....\glue 0.0 plus 0.61353
+....\TU/FandolSong(0)/m/n/12.045 字
+....\glue 0.0 plus 0.61353
+....\TU/FandolSong(0)/m/n/12.045 论
+....\glue 0.0 plus 0.61353
+....\TU/FandolSong(0)/m/n/12.045 述
+....\glue 0.0 plus 0.61353
+....\TU/FandolSong(0)/m/n/12.045 段
+....\glue 0.0 plus 0.61353
+....\TU/FandolSong(0)/m/n/12.045 落
+....\glue 0.0 plus 0.61353
+....\TU/FandolSong(0)/m/n/12.045 应
+....\glue 0.0 plus 0.61353
+....\TU/FandolSong(0)/m/n/12.045 穿
+....\glue 0.0 plus 0.61353
+....\TU/FandolSong(0)/m/n/12.045 插
+....\glue 0.0 plus 0.61353
+....\TU/FandolSong(0)/m/n/12.045 排
+....\glue 0.0 plus 0.61353
+....\TU/FandolSong(0)/m/n/12.045 版
+....\penalty 10000
+....\TU/FandolSong(0)/m/n/12.045 。
+....\rule(0.0+0.0)x-7.75697
+....\kern 0.00047
+....\kern -0.00047
+....\kern -0.18753
+....\kern 0.18753
+....\penalty 10000
+....\glue(\parfillskip) 0.0 plus 1.0fil
+....\glue(\rightskip) 0.0
+...\glue 0.0 plus 1.0fil
 ...\glue 0.0
 ...\glue 0.0 plus 0.0001fil
-..\glue(\baselineskip) 7.63202
-..\hbox(14.84546+3.5232)x417.11752
+..\glue(\baselineskip) 8.23427
+..\hbox(14.24321+3.5232)x417.11752
 ...\special{color push  Black}
-...\hbox(14.84546+3.5232)x417.11752
-....\hbox(14.84546+3.5232)x417.11752
-.....\vbox(14.84546+3.5232)x417.11752
+...\hbox(14.24321+3.5232)x417.11752
+....\hbox(14.24321+3.5232)x417.11752
+.....\vbox(14.24321+3.5232)x417.11752
 ......\rule(0.0+0.0)x417.11752
-......\glue 6.6248
+......\glue 6.02255
 ......\hbox(8.22066+3.5232)x417.11752
 .......\hbox(0.0+0.0)x0.0, glue set - 417.11752fil
 ........\vbox(0.0+0.0)x417.11752
@@ -4389,6 +4460,26 @@ Completed box being shipped out [5]
 ..........\glue(\rightskip) 0.0
 ....\glue 0.0 plus 1.0fil minus 1.0fil
 ...\special{color pop}
+LaTeX Font Info:    Font shape `TU/XITSMath-Regular(1)/m/n' will be
+(Font)              scaled to size 9.03375pt on input line ....
+LaTeX Font Info:    Font shape `TU/XITSMath-Regular(1)/m/n' will be
+(Font)              scaled to size 7.227pt on input line ....
+LaTeX Font Info:    Font shape `TU/XITSMath-Regular(2)/m/n' will be
+(Font)              scaled to size 12.0461pt on input line ....
+LaTeX Font Info:    Font shape `TU/XITSMath-Regular(2)/m/n' will be
+(Font)              scaled to size 9.03458pt on input line ....
+LaTeX Font Info:    Font shape `TU/XITSMath-Regular(2)/m/n' will be
+(Font)              scaled to size 7.22766pt on input line ....
+LaTeX Font Info:    Font shape `TU/XITSMath-Regular(3)/m/n' will be
+(Font)              scaled to size 12.0437pt on input line ....
+LaTeX Font Info:    Font shape `TU/XITSMath-Regular(3)/m/n' will be
+(Font)              scaled to size 9.03278pt on input line ....
+LaTeX Font Info:    Font shape `TU/XITSMath-Regular(3)/m/n' will be
+(Font)              scaled to size 7.22623pt on input line ....
+LaTeX Font Info:    Font shape `TU/STIXTwoMath-Regular(0)/m/n' will be
+(Font)              scaled to size 8.59444pt on input line ....
+LaTeX Font Info:    Font shape `TU/STIXTwoMath-Regular(0)/m/n' will be
+(Font)              scaled to size 6.87555pt on input line ....
 Completed box being shipped out [6]
 \vbox(722.98453+3.5232)x435.04271
 .\glue -29.59128
@@ -4464,63 +4555,194 @@ Completed box being shipped out [6]
 ....\special{color pop}
 ..\glue 15.6491
 ..\glue(\lineskip) 0.0
-..\vbox(700.50723+0.0)x417.11752, glue set 686.10927fil
-...\glue(\topskip) 2.59285
-...\hbox(9.40715+2.32468)x417.11752, glue set 75.56955fil
+..\vbox(700.50723+0.0)x417.11752, glue set 607.82516fil
+...\write-{}
+...\glue(\topskip) 1.15147
+...\hbox(10.84853+2.52943)x417.11752, glue set 346.85507fil
+....\hbox(9.79459+1.39117)x28.10498
+.....\TU/FandolHei(0)/m/n/14.05249 三
+.....\kern -0.00017
+.....\kern 0.00017
+.....\penalty 10000
+.....\TU/FandolHei(0)/m/n/14.05249 、
+.....\rule(0.0+0.0)x-9.16223
+.....\kern 0.00056
+.....\kern -0.00056
+.....\kern -0.18752
+.....\kern 0.18752
+.....\glue 9.16223 minus 7.02626
+....\TU/FandolHei(0)/m/n/14.05249 表
+....\glue 0.0 plus 0.87584
+....\TU/FandolHei(0)/m/n/14.05249 达
+....\glue 0.0 plus 0.87584
+....\TU/FandolHei(0)/m/n/14.05249 式
+....\kern -0.00017
+....\kern 0.00017
+....\penalty 10000
+....\glue(\parfillskip) 0.0 plus 1.0fil
+....\glue(\rightskip) 0.0
+...\write2{\@writefile{toc}{\protect \contentsline {subsection}{\protect \numberline {三}表达式}{\thepage }{}\protected@file@percent }}
+...\penalty 10000
+...\glue 6.02249
+...\glue(\parskip) 0.0
+...\glue(\parskip) 0.0
+...\glue(\baselineskip) 8.11433
+...\hbox(9.43123+2.21626)x417.11752, glue set 135.79454fil
 ....\hbox(0.0+0.0)x24.09
-....\TU/FandolSong(0)/m/n/12.045 不
-....\glue 0.0 plus 0.61353
-....\TU/FandolSong(0)/m/n/12.045 宜
-....\glue 0.0 plus 0.61353
-....\TU/FandolSong(0)/m/n/12.045 将
-....\glue 0.0 plus 0.61353
-....\TU/FandolSong(0)/m/n/12.045 多
-....\glue 0.0 plus 0.61353
-....\TU/FandolSong(0)/m/n/12.045 个
-....\glue 0.0 plus 0.61353
 ....\TU/FandolSong(0)/m/n/12.045 表
 ....\glue 0.0 plus 0.61353
-....\TU/FandolSong(0)/m/n/12.045 格
+....\TU/FandolSong(0)/m/n/12.045 达
+....\glue 0.0 plus 0.61353
+....\TU/FandolSong(0)/m/n/12.045 式
+....\glue 0.0 plus 0.61353
+....\TU/FandolSong(0)/m/n/12.045 主
+....\glue 0.0 plus 0.61353
+....\TU/FandolSong(0)/m/n/12.045 要
+....\glue 0.0 plus 0.61353
+....\TU/FandolSong(0)/m/n/12.045 是
+....\glue 0.0 plus 0.61353
+....\TU/FandolSong(0)/m/n/12.045 指
+....\glue 0.0 plus 0.61353
+....\TU/FandolSong(0)/m/n/12.045 分
+....\glue 0.0 plus 0.61353
+....\TU/FandolSong(0)/m/n/12.045 章
 ....\glue 0.0 plus 0.61353
 ....\TU/FandolSong(0)/m/n/12.045 连
 ....\glue 0.0 plus 0.61353
 ....\TU/FandolSong(0)/m/n/12.045 续
 ....\glue 0.0 plus 0.61353
-....\TU/FandolSong(0)/m/n/12.045 排
+....\TU/FandolSong(0)/m/n/12.045 编
 ....\glue 0.0 plus 0.61353
-....\TU/FandolSong(0)/m/n/12.045 版
+....\TU/FandolSong(0)/m/n/12.045 有
+....\glue 0.0 plus 0.61353
+....\TU/FandolSong(0)/m/n/12.045 序
+....\glue 0.0 plus 0.61353
+....\TU/FandolSong(0)/m/n/12.045 号
+....\glue 0.0 plus 0.61353
+....\TU/FandolSong(0)/m/n/12.045 的
+....\glue 0.0 plus 0.61353
+....\TU/FandolSong(0)/m/n/12.045 数
+....\glue 0.0 plus 0.61353
+....\TU/FandolSong(0)/m/n/12.045 字
+....\glue 0.0 plus 0.61353
+....\TU/FandolSong(0)/m/n/12.045 表
+....\glue 0.0 plus 0.61353
+....\TU/FandolSong(0)/m/n/12.045 达
+....\glue 0.0 plus 0.61353
+....\TU/FandolSong(0)/m/n/12.045 式
+....\penalty 10000
+....\TU/FandolSong(0)/m/n/12.045 。
+....\rule(0.0+0.0)x-7.75697
+....\kern 0.00047
+....\kern -0.00047
+....\kern -0.18753
+....\kern 0.18753
+....\penalty 10000
+....\glue(\parfillskip) 0.0 plus 1.0fil
+....\glue(\rightskip) 0.0
+...\penalty 10000
+...\glue(\abovedisplayskip) 6.02249 plus 3.01125 minus 3.01125
+...\glue(\baselineskip) 8.22273
+...\hbox(9.636+3.01152)x252.87306, shifted 164.24446
+....\hbox(5.5407+3.01152)x88.62862, display
+.....\hbox(0.0+0.0)x0.0
+.....\TU/XITSMath-Regular(1)/m/n/12.045 glyph#2523
+.....\hbox(6.10681+0.0)x5.01688, shifted 3.01152
+......\TU/XITSMath-Regular(1)/m/n/9.03375 glyph#50
+.....\glue(\thickmuskip) 3.3461 plus 3.3461
+.....\TU/XITSMath-Regular(1)/m/n/12.045 glyph#62
+.....\glue(\thickmuskip) 3.3461 plus 3.3461
+.....\TU/XITSMath-Regular(1)/m/n/12.045 glyph#2521
+.....\hbox(6.10681+0.0)x9.53375, shifted 3.01152
+......\TU/XITSMath-Regular(1)/m/n/9.03375 glyph#50
+......\TU/XITSMath-Regular(1)/m/n/9.03375 glyph#50
+.....\glue(\medmuskip) 2.67688 plus 1.33844 minus 2.67688
+.....\TU/XITSMath-Regular(1)/m/n/12.045 glyph#1155
+.....\glue(\medmuskip) 2.67688 plus 1.33844 minus 2.67688
+.....\TU/XITSMath-Regular(1)/m/n/12.045 glyph#2521
+.....\hbox(6.10681+0.0)x9.53375, shifted 3.01152
+......\TU/XITSMath-Regular(1)/m/n/9.03375 glyph#50
+......\TU/XITSMath-Regular(1)/m/n/9.03375 glyph#51
+.....\TU/XITSMath-Regular(1)/m/n/12.045 glyph#2521
+.....\hbox(6.10681+0.0)x9.53375, shifted 3.01152
+......\TU/XITSMath-Regular(1)/m/n/9.03375 glyph#51
+......\TU/XITSMath-Regular(1)/m/n/9.03375 glyph#50
+....\kern125.0982
+....\hbox(9.636+2.40898)x39.14624, display
+.....\hbox(9.636+2.40898)x39.14624
+......\kern 0.0
+......\glue 7.63654 minus 6.0225
+......\rule(0.0+0.0)x-7.63654
+......\TU/FandolSong(0)/m/n/12.045 （
+......\kern 0.00009
+......\kern -0.00009
+......\kern -0.99622
+......\kern 0.99622
+......\penalty 10000
+......\glue 0.0
+......\TU/texgyretermes(0)/m/n/12.045 2.1
+......\kern -0.0002
+......\kern 0.0002
+......\penalty 10000
+......\TU/FandolSong(0)/m/n/12.045 ）
+......\rule(0.0+0.0)x-7.63654
+......\kern 0.00047
+......\kern -0.00047
+......\kern -0.99623
+......\kern 0.99623
+......\glue 7.63654 minus 6.0225
+.....\write2{\newlabel{eq:example}{{2.1}{\thepage }{}{equation.2.1}{}}}
+...\penalty 0
+...\glue(\belowdisplayskip) 6.02249 plus 3.01125 minus 3.01125
+...\glue(\baselineskip) 7.69247
+...\hbox(9.371+2.32468)x417.11752, glue set 147.83954fil
+....\TU/FandolSong(0)/m/n/12.045 表
+....\glue 0.0 plus 0.61353
+....\TU/FandolSong(0)/m/n/12.045 达
+....\glue 0.0 plus 0.61353
+....\TU/FandolSong(0)/m/n/12.045 式
+....\glue 0.0 plus 0.61353
+....\TU/FandolSong(0)/m/n/12.045 的
+....\glue 0.0 plus 0.61353
+....\TU/FandolSong(0)/m/n/12.045 行
+....\glue 0.0 plus 0.61353
+....\TU/FandolSong(0)/m/n/12.045 距
+....\glue 0.0 plus 0.61353
+....\TU/FandolSong(0)/m/n/12.045 根
+....\glue 0.0 plus 0.61353
+....\TU/FandolSong(0)/m/n/12.045 据
+....\glue 0.0 plus 0.61353
+....\TU/FandolSong(0)/m/n/12.045 需
+....\glue 0.0 plus 0.61353
+....\TU/FandolSong(0)/m/n/12.045 要
+....\glue 0.0 plus 0.61353
+....\TU/FandolSong(0)/m/n/12.045 采
+....\glue 0.0 plus 0.61353
+....\TU/FandolSong(0)/m/n/12.045 用
 ....\penalty 10000
 ....\TU/FandolSong(0)/m/n/12.045 ，
 ....\rule(0.0+0.0)x-8.33514
 ....\glue 8.33514 minus 6.0225
 ....\glue 0.0 plus 0.61353
-....\TU/FandolSong(0)/m/n/12.045 表
+....\TU/FandolSong(0)/m/n/12.045 段
 ....\glue 0.0 plus 0.61353
-....\TU/FandolSong(0)/m/n/12.045 格
-....\glue 0.0 plus 0.61353
-....\TU/FandolSong(0)/m/n/12.045 与
-....\glue 0.0 plus 0.61353
-....\TU/FandolSong(0)/m/n/12.045 文
-....\glue 0.0 plus 0.61353
-....\TU/FandolSong(0)/m/n/12.045 字
-....\glue 0.0 plus 0.61353
-....\TU/FandolSong(0)/m/n/12.045 论
-....\glue 0.0 plus 0.61353
-....\TU/FandolSong(0)/m/n/12.045 述
+....\TU/FandolSong(0)/m/n/12.045 前
+....\glue 3.01125 plus 1.50562 minus 1.00374
+....\TU/texgyretermes(0)/m/n/12.045 6
+....\glue 3.01125 plus 1.50562 minus 1.00374
+....\TU/FandolSong(0)/m/n/12.045 磅
+....\penalty 10000
+....\TU/FandolSong(0)/m/n/12.045 、
+....\rule(0.0+0.0)x-7.85333
+....\glue 7.85333 minus 6.02249
 ....\glue 0.0 plus 0.61353
 ....\TU/FandolSong(0)/m/n/12.045 段
 ....\glue 0.0 plus 0.61353
-....\TU/FandolSong(0)/m/n/12.045 落
-....\glue 0.0 plus 0.61353
-....\TU/FandolSong(0)/m/n/12.045 应
-....\glue 0.0 plus 0.61353
-....\TU/FandolSong(0)/m/n/12.045 穿
-....\glue 0.0 plus 0.61353
-....\TU/FandolSong(0)/m/n/12.045 插
-....\glue 0.0 plus 0.61353
-....\TU/FandolSong(0)/m/n/12.045 排
-....\glue 0.0 plus 0.61353
-....\TU/FandolSong(0)/m/n/12.045 版
+....\TU/FandolSong(0)/m/n/12.045 后
+....\glue 3.01125 plus 1.50562 minus 1.00374
+....\TU/texgyretermes(0)/m/n/12.045 6
+....\glue 3.01125 plus 1.50562 minus 1.00374
+....\TU/FandolSong(0)/m/n/12.045 磅
 ....\penalty 10000
 ....\TU/FandolSong(0)/m/n/12.045 。
 ....\rule(0.0+0.0)x-7.75697
@@ -4534,15 +4756,15 @@ Completed box being shipped out [6]
 ...\glue 0.0 plus 1.0fil
 ...\glue 0.0
 ...\glue 0.0 plus 0.0001fil
-..\glue(\baselineskip) 7.63202
-..\hbox(14.84546+3.5232)x417.11752
+..\glue(\baselineskip) 8.23427
+..\hbox(14.24321+3.5232)x417.11752
 ...\special{color push  Black}
-...\hbox(14.84546+3.5232)x417.11752
+...\hbox(14.24321+3.5232)x417.11752
 ....\glue 0.0 plus 1.0fil minus 1.0fil
-....\hbox(14.84546+3.5232)x417.11752
-.....\vbox(14.84546+3.5232)x417.11752
+....\hbox(14.24321+3.5232)x417.11752
+.....\vbox(14.24321+3.5232)x417.11752
 ......\rule(0.0+0.0)x417.11752
-......\glue 6.6248
+......\glue 6.02255
 ......\hbox(8.22066+3.5232)x417.11752
 .......\hbox(0.0+0.0)x0.0, glue set - 417.11752fil
 ........\vbox(0.0+0.0)x417.11752
@@ -4575,26 +4797,7 @@ Completed box being shipped out [6]
 ..........\glue(\parfillskip) 0.0
 ..........\glue(\rightskip) 0.0
 ...\special{color pop}
-LaTeX Font Info:    Font shape `TU/XITSMath-Regular(1)/m/n' will be
-(Font)              scaled to size 9.03375pt on input line ....
-LaTeX Font Info:    Font shape `TU/XITSMath-Regular(1)/m/n' will be
-(Font)              scaled to size 7.227pt on input line ....
-LaTeX Font Info:    Font shape `TU/XITSMath-Regular(2)/m/n' will be
-(Font)              scaled to size 12.0461pt on input line ....
-LaTeX Font Info:    Font shape `TU/XITSMath-Regular(2)/m/n' will be
-(Font)              scaled to size 9.03458pt on input line ....
-LaTeX Font Info:    Font shape `TU/XITSMath-Regular(2)/m/n' will be
-(Font)              scaled to size 7.22766pt on input line ....
-LaTeX Font Info:    Font shape `TU/XITSMath-Regular(3)/m/n' will be
-(Font)              scaled to size 12.0437pt on input line ....
-LaTeX Font Info:    Font shape `TU/XITSMath-Regular(3)/m/n' will be
-(Font)              scaled to size 9.03278pt on input line ....
-LaTeX Font Info:    Font shape `TU/XITSMath-Regular(3)/m/n' will be
-(Font)              scaled to size 7.22623pt on input line ....
-LaTeX Font Info:    Font shape `TU/STIXTwoMath-Regular(0)/m/n' will be
-(Font)              scaled to size 8.59444pt on input line ....
-LaTeX Font Info:    Font shape `TU/STIXTwoMath-Regular(0)/m/n' will be
-(Font)              scaled to size 6.87555pt on input line ....
+第三章
 Completed box being shipped out [7]
 \vbox(722.98453+3.5232)x435.04271
 .\glue -29.59128
@@ -4670,215 +4873,70 @@ Completed box being shipped out [7]
 ....\special{color pop}
 ..\glue 15.6491
 ..\glue(\lineskip) 0.0
-..\vbox(700.50723+0.0)x417.11752, glue set 601.80333fil
+..\vbox(700.50723+0.0)x417.11752, glue set 630.89862fil
 ...\write-{}
-...\glue(\topskip) 1.15147
-...\hbox(10.84853+2.52943)x417.11752, glue set 346.85507fil
-....\hbox(9.79459+1.39117)x28.10498
-.....\TU/FandolHei(0)/m/n/14.05249 三
-.....\kern -0.00017
-.....\kern 0.00017
-.....\penalty 10000
-.....\TU/FandolHei(0)/m/n/14.05249 、
-.....\rule(0.0+0.0)x-9.16223
-.....\kern 0.00056
-.....\kern -0.00056
-.....\kern -0.18752
-.....\kern 0.18752
-.....\glue 9.16223 minus 7.02626
-....\TU/FandolHei(0)/m/n/14.05249 表
-....\glue 0.0 plus 0.87584
-....\TU/FandolHei(0)/m/n/14.05249 达
-....\glue 0.0 plus 0.87584
-....\TU/FandolHei(0)/m/n/14.05249 式
+...\write2{\@writefile{toc}{\protect \addvspace {12bp}}}
+...\write2{\pp@pagectr{footnote}{3}{\theabspage }{\thepage }}
+...\write2{\@writefile{toc}{\protect \contentsline {chapter}{\protect \numberline {第三章}引用}{\thepage }{}\protected@file@percent }}
+...\glue(\topskip) 12.0
+...\rule(0.0+0.0)x*
+...\penalty 10000
+...\glue 7.02625
+...\glue 0.0
+...\glue(\parskip) 0.0
+...\glue(\parskip) 0.0
+...\glue(\baselineskip) 16.88107
+...\hbox(12.55891+2.8426)x417.11752, glue set 160.37877fil
+....\glue(\leftskip) 0.0 plus 1.0fil
+....\TU/FandolHei(0)/m/n/16.06 第
+....\glue 0.0 plus 1.37729
+....\TU/FandolHei(0)/m/n/16.06 三
+....\glue 0.0 plus 1.37729
+....\TU/FandolHei(0)/m/n/16.06 章
+....\kern -0.00017
+....\kern 0.00017
+....\glue 16.06
+....\TU/FandolHei(0)/m/n/16.06 引
+....\glue 0.0 plus 1.37729
+....\TU/FandolHei(0)/m/n/16.06 用
 ....\kern -0.00017
 ....\kern 0.00017
 ....\penalty 10000
-....\glue(\parfillskip) 0.0 plus 1.0fil
-....\glue(\rightskip) 0.0
-...\write2{\@writefile{toc}{\protect \contentsline {subsection}{\protect \numberline {三}表达式}{\thepage }{}\protected@file@percent }}
+....\glue(\parfillskip) 0.0
+....\glue(\rightskip) 0.0 plus 1.0fil
 ...\penalty 10000
-...\glue 6.02249
+...\kern 1.0
 ...\glue(\parskip) 0.0
 ...\glue(\parskip) 0.0
-...\glue(\baselineskip) 10.12183
-...\hbox(9.43123+2.21626)x417.11752, glue set 135.79454fil
+...\glue(\baselineskip) 6.30714
+...\hbox(10.92525+0.0)x417.11752, glue set 380.99417fil
 ....\hbox(0.0+0.0)x24.09
-....\TU/FandolSong(0)/m/n/12.045 表
-....\glue 0.0 plus 0.61353
-....\TU/FandolSong(0)/m/n/12.045 达
-....\glue 0.0 plus 0.61353
-....\TU/FandolSong(0)/m/n/12.045 式
-....\glue 0.0 plus 0.61353
-....\TU/FandolSong(0)/m/n/12.045 主
-....\glue 0.0 plus 0.61353
-....\TU/FandolSong(0)/m/n/12.045 要
-....\glue 0.0 plus 0.61353
-....\TU/FandolSong(0)/m/n/12.045 是
-....\glue 0.0 plus 0.61353
-....\TU/FandolSong(0)/m/n/12.045 指
-....\glue 0.0 plus 0.61353
-....\TU/FandolSong(0)/m/n/12.045 分
-....\glue 0.0 plus 0.61353
-....\TU/FandolSong(0)/m/n/12.045 章
-....\glue 0.0 plus 0.61353
-....\TU/FandolSong(0)/m/n/12.045 连
-....\glue 0.0 plus 0.61353
-....\TU/FandolSong(0)/m/n/12.045 续
-....\glue 0.0 plus 0.61353
-....\TU/FandolSong(0)/m/n/12.045 编
-....\glue 0.0 plus 0.61353
-....\TU/FandolSong(0)/m/n/12.045 有
-....\glue 0.0 plus 0.61353
-....\TU/FandolSong(0)/m/n/12.045 序
-....\glue 0.0 plus 0.61353
-....\TU/FandolSong(0)/m/n/12.045 号
-....\glue 0.0 plus 0.61353
-....\TU/FandolSong(0)/m/n/12.045 的
-....\glue 0.0 plus 0.61353
-....\TU/FandolSong(0)/m/n/12.045 数
-....\glue 0.0 plus 0.61353
-....\TU/FandolSong(0)/m/n/12.045 字
-....\glue 0.0 plus 0.61353
-....\TU/FandolSong(0)/m/n/12.045 表
-....\glue 0.0 plus 0.61353
-....\TU/FandolSong(0)/m/n/12.045 达
-....\glue 0.0 plus 0.61353
-....\TU/FandolSong(0)/m/n/12.045 式
-....\penalty 10000
-....\TU/FandolSong(0)/m/n/12.045 。
-....\rule(0.0+0.0)x-7.75697
-....\kern 0.00047
-....\kern -0.00047
-....\kern -0.18753
-....\kern 0.18753
-....\penalty 10000
-....\glue(\parfillskip) 0.0 plus 1.0fil
-....\glue(\rightskip) 0.0
-...\penalty 10000
-...\glue(\abovedisplayskip) 6.02249 plus 3.01125 minus 3.01125
-...\glue(\baselineskip) 10.23022
-...\hbox(9.636+3.01152)x252.87306, shifted 164.24446
-....\hbox(5.5407+3.01152)x88.62862, display
-.....\hbox(0.0+0.0)x0.0
-.....\TU/XITSMath-Regular(1)/m/n/12.045 glyph#2523
-.....\hbox(6.10681+0.0)x5.01688, shifted 3.01152
-......\TU/XITSMath-Regular(1)/m/n/9.03375 glyph#50
-.....\glue(\thickmuskip) 3.3461 plus 3.3461
-.....\TU/XITSMath-Regular(1)/m/n/12.045 glyph#62
-.....\glue(\thickmuskip) 3.3461 plus 3.3461
-.....\TU/XITSMath-Regular(1)/m/n/12.045 glyph#2521
-.....\hbox(6.10681+0.0)x9.53375, shifted 3.01152
-......\TU/XITSMath-Regular(1)/m/n/9.03375 glyph#50
-......\TU/XITSMath-Regular(1)/m/n/9.03375 glyph#50
-.....\glue(\medmuskip) 2.67688 plus 1.33844 minus 2.67688
-.....\TU/XITSMath-Regular(1)/m/n/12.045 glyph#1155
-.....\glue(\medmuskip) 2.67688 plus 1.33844 minus 2.67688
-.....\TU/XITSMath-Regular(1)/m/n/12.045 glyph#2521
-.....\hbox(6.10681+0.0)x9.53375, shifted 3.01152
-......\TU/XITSMath-Regular(1)/m/n/9.03375 glyph#50
-......\TU/XITSMath-Regular(1)/m/n/9.03375 glyph#51
-.....\TU/XITSMath-Regular(1)/m/n/12.045 glyph#2521
-.....\hbox(6.10681+0.0)x9.53375, shifted 3.01152
-......\TU/XITSMath-Regular(1)/m/n/9.03375 glyph#51
-......\TU/XITSMath-Regular(1)/m/n/9.03375 glyph#50
-....\kern125.0982
-....\hbox(9.636+2.40898)x39.14624, display
-.....\hbox(9.636+2.40898)x39.14624
-......\kern 0.0
-......\glue 7.63654 minus 6.0225
-......\rule(0.0+0.0)x-7.63654
-......\TU/FandolSong(0)/m/n/12.045 （
-......\kern 0.00009
-......\kern -0.00009
-......\kern -0.99622
-......\kern 0.99622
-......\penalty 10000
-......\glue 0.0
-......\TU/texgyretermes(0)/m/n/12.045 2.1
+....\mathon
+....\hbox(6.10681+1.40926)x11.03336, shifted -4.81844
+.....\TU/texgyretermes(0)/m/n/9.03375 [
+.....\hbox(6.10681+0.0)x4.51688
+......\TU/texgyretermes(0)/m/n/9.03375 1
 ......\kern -0.0002
 ......\kern 0.0002
-......\penalty 10000
-......\TU/FandolSong(0)/m/n/12.045 ）
-......\rule(0.0+0.0)x-7.63654
-......\kern 0.00047
-......\kern -0.00047
-......\kern -0.99623
-......\kern 0.99623
-......\glue 7.63654 minus 6.0225
-.....\write2{\newlabel{eq:example}{{2.1}{\thepage }{}{equation.2.1}{}}}
-...\penalty 0
-...\glue(\belowdisplayskip) 6.02249 plus 3.01125 minus 3.01125
-...\glue(\baselineskip) 9.69997
-...\hbox(9.371+2.32468)x417.11752, glue set 147.83954fil
-....\TU/FandolSong(0)/m/n/12.045 表
-....\glue 0.0 plus 0.61353
-....\TU/FandolSong(0)/m/n/12.045 达
-....\glue 0.0 plus 0.61353
-....\TU/FandolSong(0)/m/n/12.045 式
-....\glue 0.0 plus 0.61353
-....\TU/FandolSong(0)/m/n/12.045 的
-....\glue 0.0 plus 0.61353
-....\TU/FandolSong(0)/m/n/12.045 行
-....\glue 0.0 plus 0.61353
-....\TU/FandolSong(0)/m/n/12.045 距
-....\glue 0.0 plus 0.61353
-....\TU/FandolSong(0)/m/n/12.045 根
-....\glue 0.0 plus 0.61353
-....\TU/FandolSong(0)/m/n/12.045 据
-....\glue 0.0 plus 0.61353
-....\TU/FandolSong(0)/m/n/12.045 需
-....\glue 0.0 plus 0.61353
-....\TU/FandolSong(0)/m/n/12.045 要
-....\glue 0.0 plus 0.61353
-....\TU/FandolSong(0)/m/n/12.045 采
-....\glue 0.0 plus 0.61353
-....\TU/FandolSong(0)/m/n/12.045 用
-....\penalty 10000
-....\TU/FandolSong(0)/m/n/12.045 ，
-....\rule(0.0+0.0)x-8.33514
-....\glue 8.33514 minus 6.0225
-....\glue 0.0 plus 0.61353
-....\TU/FandolSong(0)/m/n/12.045 段
-....\glue 0.0 plus 0.61353
-....\TU/FandolSong(0)/m/n/12.045 前
-....\glue 3.01125 plus 1.50562 minus 1.00374
-....\TU/texgyretermes(0)/m/n/12.045 6
-....\glue 3.01125 plus 1.50562 minus 1.00374
-....\TU/FandolSong(0)/m/n/12.045 磅
-....\penalty 10000
-....\TU/FandolSong(0)/m/n/12.045 、
-....\rule(0.0+0.0)x-7.85333
-....\glue 7.85333 minus 6.02249
-....\glue 0.0 plus 0.61353
-....\TU/FandolSong(0)/m/n/12.045 段
-....\glue 0.0 plus 0.61353
-....\TU/FandolSong(0)/m/n/12.045 后
-....\glue 3.01125 plus 1.50562 minus 1.00374
-....\TU/texgyretermes(0)/m/n/12.045 6
-....\glue 3.01125 plus 1.50562 minus 1.00374
-....\TU/FandolSong(0)/m/n/12.045 磅
-....\penalty 10000
-....\TU/FandolSong(0)/m/n/12.045 。
-....\rule(0.0+0.0)x-7.75697
-....\kern 0.00047
-....\kern -0.00047
-....\kern -0.18753
-....\kern 0.18753
+.....\TU/texgyretermes(0)/m/n/9.03375 ]
+.....\kern -0.0002
+.....\kern 0.0002
+....\mathoff
+....\kern 1.0
 ....\penalty 10000
 ....\glue(\parfillskip) 0.0 plus 1.0fil
 ....\glue(\rightskip) 0.0
 ...\glue 0.0 plus 1.0fil
 ...\glue 0.0
 ...\glue 0.0 plus 0.0001fil
-..\glue(\baselineskip) 7.63202
-..\hbox(14.84546+3.5232)x417.11752
+..\glue(\baselineskip) 8.23427
+..\hbox(14.24321+3.5232)x417.11752
 ...\special{color push  Black}
-...\hbox(14.84546+3.5232)x417.11752
-....\hbox(14.84546+3.5232)x417.11752
-.....\vbox(14.84546+3.5232)x417.11752
+...\hbox(14.24321+3.5232)x417.11752
+....\hbox(14.24321+3.5232)x417.11752
+.....\vbox(14.24321+3.5232)x417.11752
 ......\rule(0.0+0.0)x417.11752
-......\glue 6.6248
+......\glue 6.02255
 ......\hbox(8.22066+3.5232)x417.11752
 .......\hbox(0.0+0.0)x0.0, glue set - 417.11752fil
 ........\vbox(0.0+0.0)x417.11752
@@ -4912,7 +4970,6 @@ Completed box being shipped out [7]
 ..........\glue(\rightskip) 0.0
 ....\glue 0.0 plus 1.0fil minus 1.0fil
 ...\special{color pop}
-第三章
 Completed box being shipped out [8]
 \vbox(722.98453+3.5232)x435.04271
 .\glue -29.59128
@@ -4988,11 +5045,10 @@ Completed box being shipped out [8]
 ....\special{color pop}
 ..\glue 15.6491
 ..\glue(\lineskip) 0.0
-..\vbox(700.50723+0.0)x417.11752, glue set 628.89134fil
+..\vbox(700.50723+0.0)x417.11752, glue set 586.44757fil
 ...\write-{}
 ...\write2{\@writefile{toc}{\protect \addvspace {12bp}}}
-...\write2{\pp@pagectr{footnote}{3}{\theabspage }{\thepage }}
-...\write2{\@writefile{toc}{\protect \contentsline {chapter}{\protect \numberline {第三章}引用}{\thepage }{}\protected@file@percent }}
+...\write2{\@writefile{toc}{\protect \contentsline {chapter}{参考文献}{\thepage }{}\protected@file@percent }}
 ...\glue(\topskip) 12.0
 ...\rule(0.0+0.0)x*
 ...\penalty 10000
@@ -5000,59 +5056,123 @@ Completed box being shipped out [8]
 ...\glue 0.0
 ...\glue(\parskip) 0.0
 ...\glue(\parskip) 0.0
-...\glue(\baselineskip) 16.88107
-...\hbox(12.55891+2.8426)x417.11752, glue set 160.37877fil
+...\glue(\baselineskip) 18.94077
+...\hbox(14.18298+3.39667)x417.11752, glue set 158.87318fil
 ....\glue(\leftskip) 0.0 plus 1.0fil
-....\TU/FandolHei(0)/m/n/16.06 第
-....\glue 0.0 plus 1.37729
-....\TU/FandolHei(0)/m/n/16.06 三
-....\glue 0.0 plus 1.37729
-....\TU/FandolHei(0)/m/n/16.06 章
-....\kern -0.00017
-....\kern 0.00017
-....\glue 16.06
-....\TU/FandolHei(0)/m/n/16.06 引
-....\glue 0.0 plus 1.37729
-....\TU/FandolHei(0)/m/n/16.06 用
+....\TU/FandolHei(0)/m/n/18.06749 参
+....\glue 9.03374 plus 1.40234 minus 0.4979
+....\TU/FandolHei(0)/m/n/18.06749 考
+....\glue 9.03374 plus 1.40234 minus 0.4979
+....\TU/FandolHei(0)/m/n/18.06749 文
+....\glue 9.03374 plus 1.40234 minus 0.4979
+....\TU/FandolHei(0)/m/n/18.06749 献
 ....\kern -0.00017
 ....\kern 0.00017
 ....\penalty 10000
 ....\glue(\parfillskip) 0.0
 ....\glue(\rightskip) 0.0 plus 1.0fil
 ...\penalty 10000
-...\kern 1.0
+...\glue 19.07124
 ...\glue(\parskip) 0.0
 ...\glue(\parskip) 0.0
-...\glue(\baselineskip) 8.31464
-...\hbox(10.92525+0.0)x417.11752, glue set 380.99417fil
-....\hbox(0.0+0.0)x24.09
-....\mathon
-....\hbox(6.10681+1.40926)x11.03336, shifted -4.81844
-.....\TU/texgyretermes(0)/m/n/9.03375 [
-.....\hbox(6.10681+0.0)x4.51688
-......\TU/texgyretermes(0)/m/n/9.03375 1
+...\glue(\baselineskip) 8.4516
+...\hbox(8.22673+2.71011)x387.00504, glue set - 0.07979, shifted 30.11249
+....\hbox(8.14243+1.879)x0.0
+.....\glue 0.0
+.....\glue -30.11249
+.....\glue 0.0
+.....\hbox(8.14243+1.879)x30.11249, glue set 16.06802fill
+......\special{color push  Black}
+......\glue 0.0 plus 1.0fil
+......\glue 0.0 plus 1.0fil
+......\TU/texgyretermes(0)/m/n/12.045 [1]
 ......\kern -0.0002
 ......\kern 0.0002
-.....\TU/texgyretermes(0)/m/n/9.03375 ]
+......\glue 0.0 plus 1.0fill
+......\special{color pop}
+.....\glue 0.0
+....\penalty 0
+....\TU/texgyretermes(0)/m/n/12.045 KNUTH
+....\kern -0.0002
+....\kern 0.0002
+....\penalty 10000
+....\glue 3.01125 plus 1.50562 minus 1.00374
+....\TU/texgyretermes(0)/m/n/12.045 D
+....\kern -0.0002
+....\kern 0.0002
+....\penalty 10000
+....\glue 3.01125 plus 1.50562 minus 1.00374
+....\TU/texgyretermes(0)/m/n/12.045 E.
+....\glue 3.01125 plus 1.50562 minus 1.00374
+....\glue 1.32495 plus 3.97487 minus 0.84323
+....\TU/texgyretermes(0)/m/n/12.045 Computers
+....\glue 3.01125 plus 1.50562 minus 1.00374
+....\TU/texgyretermes(0)/m/n/12.045 and
+....\glue 3.01125 plus 1.50562 minus 1.00374
+....\TU/texgyretermes(0)/m/n/12.045 typesetting:
+....\glue 4.01498 plus 3.01123 minus 0.50186
+....\TU/texgyretermes(0)/m/n/12.045 volume
+....\kern -0.0002
+....\kern 0.0002
+....\penalty 10000
+....\glue 3.01125 plus 1.50562 minus 1.00374
+....\TU/texgyretermes(0)/m/n/12.045 A
+....\kern -0.0002
+....\kern 0.0002
+....\glue 12.045
+....\TU/texgyretermes(0)/m/n/12.045 The
+....\glue 3.01125 plus 1.50562 minus 1.00374
+....\TU/texgyretermes(0)/m/n/12.045 T
+....\kern -0.0002
+....\kern 0.0002
+....\kern -2.00792
+....\hbox(7.97379+0.0)x7.3595, shifted 2.71011
+.....\TU/texgyretermes(0)/m/n/12.045 E
 .....\kern -0.0002
 .....\kern 0.0002
-....\mathoff
-....\kern 1.0
+....\kern -1.50562
+....\TU/texgyretermes(0)/m/n/12.045 X
+....\kern -0.0002
+....\kern 0.0002
+....\TU/texgyretermes(0)/m/n/12.045 book
+....\kern -0.0002
+....\kern 0.0002
+....\penalty 0
+....\TU/texgyretermes(0)/m/n/12.045 [M].
+....\glue 3.01125 plus 1.50562 minus 1.00374
+....\glue 1.32495 plus 3.97487 minus 0.84323
+....\TU/texgyretermes(0)/m/n/12.045 Read-
+....\glue(\rightskip) 0.0
+...\penalty 14100
+...\glue(\baselineskip) 9.1261
+...\hbox(8.23878+2.6258)x387.00504, glue set 199.12717fil, shifted 30.11249
+....\TU/texgyretermes(0)/m/n/12.045 ing,
+....\glue 3.01125 plus 1.88202 minus 0.80298
+....\TU/texgyretermes(0)/m/n/12.045 MA,
+....\glue 3.01125 plus 1.50562 minus 1.00374
+....\TU/texgyretermes(0)/m/n/12.045 USA:
+....\glue 3.01125 plus 1.50562 minus 1.00374
+....\TU/texgyretermes(0)/m/n/12.045 Addison-Wesley,
+....\glue 3.01125 plus 1.88202 minus 0.80298
+....\TU/texgyretermes(0)/m/n/12.045 1986.
 ....\penalty 10000
 ....\glue(\parfillskip) 0.0 plus 1.0fil
 ....\glue(\rightskip) 0.0
+...\penalty -51
+...\glue 0.0 plus 0.2
+...\glue 0.0 plus -0.2
 ...\glue 0.0 plus 1.0fil
 ...\glue 0.0
 ...\glue 0.0 plus 0.0001fil
-..\glue(\baselineskip) 7.63202
-..\hbox(14.84546+3.5232)x417.11752
+..\glue(\baselineskip) 8.23427
+..\hbox(14.24321+3.5232)x417.11752
 ...\special{color push  Black}
-...\hbox(14.84546+3.5232)x417.11752
+...\hbox(14.24321+3.5232)x417.11752
 ....\glue 0.0 plus 1.0fil minus 1.0fil
-....\hbox(14.84546+3.5232)x417.11752
-.....\vbox(14.84546+3.5232)x417.11752
+....\hbox(14.24321+3.5232)x417.11752
+.....\vbox(14.24321+3.5232)x417.11752
 ......\rule(0.0+0.0)x417.11752
-......\glue 6.6248
+......\glue 6.02255
 ......\hbox(8.22066+3.5232)x417.11752
 .......\hbox(0.0+0.0)x0.0, glue set - 417.11752fil
 ........\vbox(0.0+0.0)x417.11752
@@ -5085,6 +5205,7 @@ Completed box being shipped out [8]
 ..........\glue(\parfillskip) 0.0
 ..........\glue(\rightskip) 0.0
 ...\special{color pop}
+附录 A
 Completed box being shipped out [9]
 \vbox(722.98453+3.5232)x435.04271
 .\glue -29.59128
@@ -5160,10 +5281,10 @@ Completed box being shipped out [9]
 ....\special{color pop}
 ..\glue 15.6491
 ..\glue(\lineskip) 0.0
-..\vbox(700.50723+0.0)x417.11752, glue set 582.43301fil
+..\vbox(700.50723+0.0)x417.11752, glue set 610.62532fil
 ...\write-{}
-...\write2{\@writefile{toc}{\protect \addvspace {12bp}}}
-...\write2{\@writefile{toc}{\protect \contentsline {chapter}{参考文献}{\thepage }{}\protected@file@percent }}
+...\write2{\pp@pagectr{footnote}{4}{\theabspage }{\thepage }}
+...\write2{\@writefile{toc}{\protect \contentsline {chapter}{\protect \numberline {附录 A}附录章节}{\thepage }{}\protected@file@percent }}
 ...\glue(\topskip) 12.0
 ...\rule(0.0+0.0)x*
 ...\penalty 10000
@@ -5171,16 +5292,26 @@ Completed box being shipped out [9]
 ...\glue 0.0
 ...\glue(\parskip) 0.0
 ...\glue(\parskip) 0.0
-...\glue(\baselineskip) 18.94077
-...\hbox(14.18298+3.39667)x417.11752, glue set 158.87318fil
+...\glue(\baselineskip) 16.88107
+...\hbox(12.55891+2.7623)x417.11752, glue set 144.76042fil
 ....\glue(\leftskip) 0.0 plus 1.0fil
-....\TU/FandolHei(0)/m/n/18.06749 参
-....\glue 9.03374 plus 1.40234 minus 0.4979
-....\TU/FandolHei(0)/m/n/18.06749 考
-....\glue 9.03374 plus 1.40234 minus 0.4979
-....\TU/FandolHei(0)/m/n/18.06749 文
-....\glue 9.03374 plus 1.40234 minus 0.4979
-....\TU/FandolHei(0)/m/n/18.06749 献
+....\TU/FandolHei(0)/m/n/16.06 附
+....\glue 0.0 plus 1.37729
+....\TU/FandolHei(0)/m/n/16.06 录
+....\kern -0.00018
+....\kern 0.00018
+....\glue 4.46468 plus 2.23233 minus 1.48822
+....\TU/texgyreheros(0)/m/n/16.06 A
+....\kern -0.0002
+....\kern 0.0002
+....\glue 16.06
+....\TU/FandolHei(0)/m/n/16.06 附
+....\glue 0.0 plus 1.37729
+....\TU/FandolHei(0)/m/n/16.06 录
+....\glue 0.0 plus 1.37729
+....\TU/FandolHei(0)/m/n/16.06 章
+....\glue 0.0 plus 1.37729
+....\TU/FandolHei(0)/m/n/16.06 节
 ....\kern -0.00017
 ....\kern 0.00017
 ....\penalty 10000
@@ -5190,103 +5321,37 @@ Completed box being shipped out [9]
 ...\glue 19.07124
 ...\glue(\parskip) 0.0
 ...\glue(\parskip) 0.0
-...\glue(\baselineskip) 10.45909
-...\hbox(8.22673+2.71011)x387.00504, glue set - 0.07979, shifted 30.11249
-....\hbox(8.14243+1.879)x0.0
-.....\glue 0.0
-.....\glue -30.11249
-.....\glue 0.0
-.....\hbox(8.14243+1.879)x30.11249, glue set 16.06802fill
-......\special{color push  Black}
-......\glue 0.0 plus 1.0fil
-......\glue 0.0 plus 1.0fil
-......\TU/texgyretermes(0)/m/n/12.045 [1]
-......\kern -0.0002
-......\kern 0.0002
-......\glue 0.0 plus 1.0fill
-......\special{color pop}
-.....\glue 0.0
-....\penalty 0
-....\TU/texgyretermes(0)/m/n/12.045 KNUTH
-....\kern -0.0002
-....\kern 0.0002
+...\glue(\baselineskip) 8.0019
+...\hbox(9.31079+2.20422)x417.11752, glue set 340.55951fil
+....\hbox(0.0+0.0)x24.09
+....\TU/FandolSong(0)/m/n/12.045 附
+....\glue 0.0 plus 0.61353
+....\TU/FandolSong(0)/m/n/12.045 录
+....\glue 0.0 plus 0.61353
+....\TU/FandolSong(0)/m/n/12.045 内
+....\glue 0.0 plus 0.61353
+....\TU/FandolSong(0)/m/n/12.045 容
 ....\penalty 10000
-....\glue 3.01125 plus 1.50562 minus 1.00374
-....\TU/texgyretermes(0)/m/n/12.045 D
-....\kern -0.0002
-....\kern 0.0002
-....\penalty 10000
-....\glue 3.01125 plus 1.50562 minus 1.00374
-....\TU/texgyretermes(0)/m/n/12.045 E.
-....\glue 3.01125 plus 1.50562 minus 1.00374
-....\glue 1.32495 plus 3.97487 minus 0.84323
-....\TU/texgyretermes(0)/m/n/12.045 Computers
-....\glue 3.01125 plus 1.50562 minus 1.00374
-....\TU/texgyretermes(0)/m/n/12.045 and
-....\glue 3.01125 plus 1.50562 minus 1.00374
-....\TU/texgyretermes(0)/m/n/12.045 typesetting:
-....\glue 4.01498 plus 3.01123 minus 0.50186
-....\TU/texgyretermes(0)/m/n/12.045 volume
-....\kern -0.0002
-....\kern 0.0002
-....\penalty 10000
-....\glue 3.01125 plus 1.50562 minus 1.00374
-....\TU/texgyretermes(0)/m/n/12.045 A
-....\kern -0.0002
-....\kern 0.0002
-....\glue 12.045
-....\TU/texgyretermes(0)/m/n/12.045 The
-....\glue 3.01125 plus 1.50562 minus 1.00374
-....\TU/texgyretermes(0)/m/n/12.045 T
-....\kern -0.0002
-....\kern 0.0002
-....\kern -2.00792
-....\hbox(7.97379+0.0)x7.3595, shifted 2.71011
-.....\TU/texgyretermes(0)/m/n/12.045 E
-.....\kern -0.0002
-.....\kern 0.0002
-....\kern -1.50562
-....\TU/texgyretermes(0)/m/n/12.045 X
-....\kern -0.0002
-....\kern 0.0002
-....\TU/texgyretermes(0)/m/n/12.045 book
-....\kern -0.0002
-....\kern 0.0002
-....\penalty 0
-....\TU/texgyretermes(0)/m/n/12.045 [M].
-....\glue 3.01125 plus 1.50562 minus 1.00374
-....\glue 1.32495 plus 3.97487 minus 0.84323
-....\TU/texgyretermes(0)/m/n/12.045 Read-
-....\glue(\rightskip) 0.0
-...\penalty 14100
-...\glue(\baselineskip) 11.13359
-...\hbox(8.23878+2.6258)x387.00504, glue set 199.12717fil, shifted 30.11249
-....\TU/texgyretermes(0)/m/n/12.045 ing,
-....\glue 3.01125 plus 1.88202 minus 0.80298
-....\TU/texgyretermes(0)/m/n/12.045 MA,
-....\glue 3.01125 plus 1.50562 minus 1.00374
-....\TU/texgyretermes(0)/m/n/12.045 USA:
-....\glue 3.01125 plus 1.50562 minus 1.00374
-....\TU/texgyretermes(0)/m/n/12.045 Addison-Wesley,
-....\glue 3.01125 plus 1.88202 minus 0.80298
-....\TU/texgyretermes(0)/m/n/12.045 1986.
+....\TU/FandolSong(0)/m/n/12.045 。
+....\rule(0.0+0.0)x-7.75697
+....\kern 0.00047
+....\kern -0.00047
+....\kern -0.18753
+....\kern 0.18753
 ....\penalty 10000
 ....\glue(\parfillskip) 0.0 plus 1.0fil
 ....\glue(\rightskip) 0.0
-...\penalty -51
-...\glue 0.0 plus 0.2
-...\glue 0.0 plus -0.2
 ...\glue 0.0 plus 1.0fil
 ...\glue 0.0
 ...\glue 0.0 plus 0.0001fil
-..\glue(\baselineskip) 7.63202
-..\hbox(14.84546+3.5232)x417.11752
+..\glue(\baselineskip) 8.23427
+..\hbox(14.24321+3.5232)x417.11752
 ...\special{color push  Black}
-...\hbox(14.84546+3.5232)x417.11752
-....\hbox(14.84546+3.5232)x417.11752
-.....\vbox(14.84546+3.5232)x417.11752
+...\hbox(14.24321+3.5232)x417.11752
+....\hbox(14.24321+3.5232)x417.11752
+.....\vbox(14.24321+3.5232)x417.11752
 ......\rule(0.0+0.0)x417.11752
-......\glue 6.6248
+......\glue 6.02255
 ......\hbox(8.22066+3.5232)x417.11752
 .......\hbox(0.0+0.0)x0.0, glue set - 417.11752fil
 ........\vbox(0.0+0.0)x417.11752
@@ -5320,7 +5385,7 @@ Completed box being shipped out [9]
 ..........\glue(\rightskip) 0.0
 ....\glue 0.0 plus 1.0fil minus 1.0fil
 ...\special{color pop}
-附录 A
+)
 Completed box being shipped out [10]
 \vbox(722.98453+3.5232)x435.04271
 .\glue -29.59128
@@ -5396,10 +5461,10 @@ Completed box being shipped out [10]
 ....\special{color pop}
 ..\glue 15.6491
 ..\glue(\lineskip) 0.0
-..\vbox(700.50723+0.0)x417.11752, glue set 608.61804fil
+..\vbox(700.50723+0.0)x417.11752, glue set 566.9528fil
 ...\write-{}
-...\write2{\pp@pagectr{footnote}{4}{\theabspage }{\thepage }}
-...\write2{\@writefile{toc}{\protect \contentsline {chapter}{\protect \numberline {附录 A}附录章节}{\thepage }{}\protected@file@percent }}
+...\write-{}
+...\write2{\@writefile{toc}{\protect \contentsline {chapter}{致谢}{\thepage }{}\protected@file@percent }}
 ...\glue(\topskip) 12.0
 ...\rule(0.0+0.0)x*
 ...\penalty 10000
@@ -5407,26 +5472,12 @@ Completed box being shipped out [10]
 ...\glue 0.0
 ...\glue(\parskip) 0.0
 ...\glue(\parskip) 0.0
-...\glue(\baselineskip) 16.88107
-...\hbox(12.55891+2.7623)x417.11752, glue set 144.76042fil
+...\glue(\baselineskip) 19.13951
+...\hbox(13.98424+3.30634)x417.11752, glue set 181.45753fil
 ....\glue(\leftskip) 0.0 plus 1.0fil
-....\TU/FandolHei(0)/m/n/16.06 附
-....\glue 0.0 plus 1.37729
-....\TU/FandolHei(0)/m/n/16.06 录
-....\kern -0.00018
-....\kern 0.00018
-....\glue 4.46468 plus 2.23233 minus 1.48822
-....\TU/texgyreheros(0)/m/n/16.06 A
-....\kern -0.0002
-....\kern 0.0002
-....\glue 16.06
-....\TU/FandolHei(0)/m/n/16.06 附
-....\glue 0.0 plus 1.37729
-....\TU/FandolHei(0)/m/n/16.06 录
-....\glue 0.0 plus 1.37729
-....\TU/FandolHei(0)/m/n/16.06 章
-....\glue 0.0 plus 1.37729
-....\TU/FandolHei(0)/m/n/16.06 节
+....\TU/FandolHei(0)/m/n/18.06749 致
+....\glue 18.06749 plus 0.1423 minus 2.88081
+....\TU/FandolHei(0)/m/n/18.06749 谢
 ....\kern -0.00017
 ....\kern 0.00017
 ....\penalty 10000
@@ -5436,12 +5487,12 @@ Completed box being shipped out [10]
 ...\glue 19.07124
 ...\glue(\parskip) 0.0
 ...\glue(\parskip) 0.0
-...\glue(\baselineskip) 10.0094
-...\hbox(9.31079+2.20422)x417.11752, glue set 340.55951fil
+...\glue(\baselineskip) 7.44583
+...\hbox(9.32283+2.20422)x417.11752, glue set 340.55951fil
 ....\hbox(0.0+0.0)x24.09
-....\TU/FandolSong(0)/m/n/12.045 附
+....\TU/FandolSong(0)/m/n/12.045 致
 ....\glue 0.0 plus 0.61353
-....\TU/FandolSong(0)/m/n/12.045 录
+....\TU/FandolSong(0)/m/n/12.045 谢
 ....\glue 0.0 plus 0.61353
 ....\TU/FandolSong(0)/m/n/12.045 内
 ....\glue 0.0 plus 0.61353
@@ -5456,18 +5507,38 @@ Completed box being shipped out [10]
 ....\penalty 10000
 ....\glue(\parfillskip) 0.0 plus 1.0fil
 ....\glue(\rightskip) 0.0
+...\glue(\baselineskip) 17.87077
+...\hbox(0.0+0.0)x0.0
+...\glue(\parskip) 0.0
+...\glue(\parskip) 0.0
+...\glue(\baselineskip) 10.77626
+...\hbox(9.29874+2.04764)x417.11752, glue set 353.88129fil
+....\glue(\leftskip) 0.0 plus 1.0fil
+....\hbox(0.0+0.0)x0.0
+....\TU/texgyretermes(0)/m/n/12.045 2016
+....\glue 3.01125 plus 1.50562 minus 1.00374
+....\TU/FandolSong(0)/m/n/12.045 年
+....\glue 3.01125 plus 1.50562 minus 1.00374
+....\TU/texgyretermes(0)/m/n/12.045 5
+....\glue 3.01125 plus 1.50562 minus 1.00374
+....\TU/FandolSong(0)/m/n/12.045 月
+....\kern -0.00017
+....\kern 0.00017
+....\penalty 10000
+....\glue(\parfillskip) 0.0
+....\glue(\rightskip) 0.0
 ...\glue 0.0 plus 1.0fil
 ...\glue 0.0
 ...\glue 0.0 plus 0.0001fil
-..\glue(\baselineskip) 7.63202
-..\hbox(14.84546+3.5232)x417.11752
+..\glue(\baselineskip) 8.23427
+..\hbox(14.24321+3.5232)x417.11752
 ...\special{color push  Black}
-...\hbox(14.84546+3.5232)x417.11752
+...\hbox(14.24321+3.5232)x417.11752
 ....\glue 0.0 plus 1.0fil minus 1.0fil
-....\hbox(14.84546+3.5232)x417.11752
-.....\vbox(14.84546+3.5232)x417.11752
+....\hbox(14.24321+3.5232)x417.11752
+.....\vbox(14.24321+3.5232)x417.11752
 ......\rule(0.0+0.0)x417.11752
-......\glue 6.6248
+......\glue 6.02255
 ......\hbox(8.22066+3.5232)x417.11752
 .......\hbox(0.0+0.0)x0.0, glue set - 417.11752fil
 ........\vbox(0.0+0.0)x417.11752
@@ -5499,190 +5570,4 @@ Completed box being shipped out [10]
 ..........\penalty 10000
 ..........\glue(\parfillskip) 0.0
 ..........\glue(\rightskip) 0.0
-...\special{color pop}
-)
-Completed box being shipped out [11]
-\vbox(722.98453+3.5232)x435.04271
-.\glue -29.59128
-.\vbox(752.5758+3.5232)x417.11752, shifted 17.92519
-..\vbox(13.942+0.0)x417.11752, glue set 2.19815fil
-...\glue 0.0 plus 1.0fil
-...\hbox(11.74385+0.0)x417.11752
-....\special{color push  Black}
-....\hbox(11.74385+0.0)x417.11752
-.....\hbox(11.74385+0.0)x417.11752
-......\vbox(11.74385+0.0)x417.11752
-.......\hbox(8.22066+3.5232)x417.11752
-........\hbox(0.0+0.0)x0.0, glue set - 417.11752fil
-.........\vbox(0.0+0.0)x417.11752
-..........\hbox(0.0+0.0)x417.11752, glue set 208.55876fil
-...........\hbox(0.0+0.0)x0.0
-...........\penalty 10000
-...........\glue(\parfillskip) 0.0 plus 1.0fil
-...........\glue(\rightskip) 0.0 plus 1.0fil
-.........\glue 0.0 plus 1.0fil minus 1.0fil
-........\glue 0.0 plus 1.0fill
-........\vbox(8.22066+3.5232)x417.11752
-.........\hbox(8.22066+3.5232)x417.11752, glue set 145.3226fil
-..........\glue(\leftskip) 0.0 plus 1.0fil
-..........\hbox(0.0+0.0)x0.0
-..........\TU/FandolSong(0)/m/n/9.03374 中
-..........\glue 0.0 plus 0.24089
-..........\TU/FandolSong(0)/m/n/9.03374 国
-..........\glue 0.0 plus 0.24089
-..........\TU/FandolSong(0)/m/n/9.03374 科
-..........\glue 0.0 plus 0.24089
-..........\TU/FandolSong(0)/m/n/9.03374 学
-..........\glue 0.0 plus 0.24089
-..........\TU/FandolSong(0)/m/n/9.03374 技
-..........\glue 0.0 plus 0.24089
-..........\TU/FandolSong(0)/m/n/9.03374 术
-..........\glue 0.0 plus 0.24089
-..........\TU/FandolSong(0)/m/n/9.03374 大
-..........\glue 0.0 plus 0.24089
-..........\TU/FandolSong(0)/m/n/9.03374 学
-..........\glue 0.0 plus 0.24089
-..........\TU/FandolSong(0)/m/n/9.03374 本
-..........\glue 0.0 plus 0.24089
-..........\TU/FandolSong(0)/m/n/9.03374 科
-..........\glue 0.0 plus 0.24089
-..........\TU/FandolSong(0)/m/n/9.03374 毕
-..........\glue 0.0 plus 0.24089
-..........\TU/FandolSong(0)/m/n/9.03374 业
-..........\glue 0.0 plus 0.24089
-..........\TU/FandolSong(0)/m/n/9.03374 论
-..........\glue 0.0 plus 0.24089
-..........\TU/FandolSong(0)/m/n/9.03374 文
-..........\kern -0.00017
-..........\kern 0.00017
-..........\rule(8.22066+3.5232)x0.0
-..........\penalty 10000
-..........\glue(\parfillskip) 0.0
-..........\glue(\rightskip) 0.0 plus 1.0fil
-........\glue 0.0 plus 1.0fill
-........\hbox(0.0+0.0)x0.0, glue set - 417.11752fil
-.........\glue 0.0 plus 1.0fil minus 1.0fil
-.........\vbox(0.0+0.0)x417.11752
-..........\hbox(0.0+0.0)x417.11752, glue set 417.11752fil
-...........\glue(\leftskip) 0.0 plus 1.0fil
-...........\hbox(0.0+0.0)x0.0
-...........\penalty 10000
-...........\glue(\parfillskip) 0.0
-...........\glue(\rightskip) 0.0
-.......\glue 0.0
-.......\rule(0.7528+0.0)x417.11752
-.......\glue -0.7528
-.....\glue 0.0 plus 1.0fil minus 1.0fil
-....\special{color pop}
-..\glue 15.6491
-..\glue(\lineskip) 0.0
-..\vbox(700.50723+0.0)x417.11752, glue set 560.93097fil
-...\write-{}
-...\write-{}
-...\write2{\@writefile{toc}{\protect \contentsline {chapter}{致谢}{\thepage }{}\protected@file@percent }}
-...\glue(\topskip) 12.0
-...\rule(0.0+0.0)x*
-...\penalty 10000
-...\glue 7.02625
-...\glue 0.0
-...\glue(\parskip) 0.0
-...\glue(\parskip) 0.0
-...\glue(\baselineskip) 19.13951
-...\hbox(13.98424+3.30634)x417.11752, glue set 181.45753fil
-....\glue(\leftskip) 0.0 plus 1.0fil
-....\TU/FandolHei(0)/m/n/18.06749 致
-....\glue 18.06749 plus 0.1423 minus 2.88081
-....\TU/FandolHei(0)/m/n/18.06749 谢
-....\kern -0.00017
-....\kern 0.00017
-....\penalty 10000
-....\glue(\parfillskip) 0.0
-....\glue(\rightskip) 0.0 plus 1.0fil
-...\penalty 10000
-...\glue 19.07124
-...\glue(\parskip) 0.0
-...\glue(\parskip) 0.0
-...\glue(\baselineskip) 9.45332
-...\hbox(9.32283+2.20422)x417.11752, glue set 340.55951fil
-....\hbox(0.0+0.0)x24.09
-....\TU/FandolSong(0)/m/n/12.045 致
-....\glue 0.0 plus 0.61353
-....\TU/FandolSong(0)/m/n/12.045 谢
-....\glue 0.0 plus 0.61353
-....\TU/FandolSong(0)/m/n/12.045 内
-....\glue 0.0 plus 0.61353
-....\TU/FandolSong(0)/m/n/12.045 容
-....\penalty 10000
-....\TU/FandolSong(0)/m/n/12.045 。
-....\rule(0.0+0.0)x-7.75697
-....\kern 0.00047
-....\kern -0.00047
-....\kern -0.18753
-....\kern 0.18753
-....\penalty 10000
-....\glue(\parfillskip) 0.0 plus 1.0fil
-....\glue(\rightskip) 0.0
-...\glue(\baselineskip) 19.87827
-...\hbox(0.0+0.0)x0.0
-...\glue(\parskip) 0.0
-...\glue(\parskip) 0.0
-...\glue(\baselineskip) 12.78375
-...\hbox(9.29874+2.04764)x417.11752, glue set 353.88129fil
-....\glue(\leftskip) 0.0 plus 1.0fil
-....\hbox(0.0+0.0)x0.0
-....\TU/texgyretermes(0)/m/n/12.045 2016
-....\glue 3.01125 plus 1.50562 minus 1.00374
-....\TU/FandolSong(0)/m/n/12.045 年
-....\glue 3.01125 plus 1.50562 minus 1.00374
-....\TU/texgyretermes(0)/m/n/12.045 5
-....\glue 3.01125 plus 1.50562 minus 1.00374
-....\TU/FandolSong(0)/m/n/12.045 月
-....\kern -0.00017
-....\kern 0.00017
-....\penalty 10000
-....\glue(\parfillskip) 0.0
-....\glue(\rightskip) 0.0
-...\glue 0.0 plus 1.0fil
-...\glue 0.0
-...\glue 0.0 plus 0.0001fil
-..\glue(\baselineskip) 7.63202
-..\hbox(14.84546+3.5232)x417.11752
-...\special{color push  Black}
-...\hbox(14.84546+3.5232)x417.11752
-....\hbox(14.84546+3.5232)x417.11752
-.....\vbox(14.84546+3.5232)x417.11752
-......\rule(0.0+0.0)x417.11752
-......\glue 6.6248
-......\hbox(8.22066+3.5232)x417.11752
-.......\hbox(0.0+0.0)x0.0, glue set - 417.11752fil
-........\vbox(0.0+0.0)x417.11752
-.........\hbox(0.0+0.0)x417.11752, glue set 208.55876fil
-..........\hbox(0.0+0.0)x0.0
-..........\penalty 10000
-..........\glue(\parfillskip) 0.0 plus 1.0fil
-..........\glue(\rightskip) 0.0 plus 1.0fil
-........\glue 0.0 plus 1.0fil minus 1.0fil
-.......\glue 0.0 plus 1.0fill
-.......\vbox(8.22066+3.5232)x417.11752
-........\hbox(8.22066+3.5232)x417.11752, glue set 204.0419fil
-.........\glue(\leftskip) 0.0 plus 1.0fil
-.........\hbox(0.0+0.0)x0.0
-.........\TU/texgyretermes(0)/m/n/9.03374 11
-.........\kern -0.0002
-.........\kern 0.0002
-.........\rule(8.22066+3.5232)x0.0
-.........\penalty 10000
-.........\glue(\parfillskip) 0.0
-.........\glue(\rightskip) 0.0 plus 1.0fil
-.......\glue 0.0 plus 1.0fill
-.......\hbox(0.0+0.0)x0.0, glue set - 417.11752fil
-........\glue 0.0 plus 1.0fil minus 1.0fil
-........\vbox(0.0+0.0)x417.11752
-.........\hbox(0.0+0.0)x417.11752, glue set 417.11752fil
-..........\glue(\leftskip) 0.0 plus 1.0fil
-..........\hbox(0.0+0.0)x0.0
-..........\penalty 10000
-..........\glue(\parfillskip) 0.0
-..........\glue(\rightskip) 0.0
-....\glue 0.0 plus 1.0fil minus 1.0fil
 ...\special{color pop}

--- a/test/testfiles-crossref/main-bachelor.tlg
+++ b/test/testfiles-crossref/main-bachelor.tlg
@@ -2414,8 +2414,7 @@ Completed box being shipped out [4]
 ...\glue(\parskip) 0.0
 ...\glue(\parskip) 0.0
 ...\glue(\baselineskip) 13.47435
-...\hbox(11.8041+2.66495)x417.11752, glue set 88.10881fil
-....\glue(\leftskip) 0.0 plus 1.0fil
+...\hbox(11.8041+2.66495)x417.11752, glue set 176.21762fil
 ....\hbox(11.77399+2.66495)x60.22498
 .....\TU/FandolHei(0)/m/n/15.05624 第
 .....\glue 0.0 plus 1.02621
@@ -2451,8 +2450,8 @@ Completed box being shipped out [4]
 ....\kern -0.00017
 ....\kern 0.00017
 ....\penalty 10000
-....\glue(\parfillskip) 0.0
-....\glue(\rightskip) 0.0 plus 1.0fil
+....\glue(\parfillskip) 0.0 plus 1.0fil
+....\glue(\rightskip) 0.0
 ...\write2{\@writefile{toc}{\protect \contentsline {section}{\protect \numberline {第一节}学位论文中的常见问题分析}{\thepage }{}\protected@file@percent }}
 ...\penalty 10000
 ...\glue 6.02249
@@ -3200,8 +3199,7 @@ Completed box being shipped out [5]
 ...\glue(\parskip) 0.0
 ...\glue(\parskip) 0.0
 ...\glue(\baselineskip) 12.98653
-...\hbox(11.77399+2.71011)x417.11752, glue set 110.69318fil
-....\glue(\leftskip) 0.0 plus 1.0fil
+...\hbox(11.77399+2.71011)x417.11752, glue set 221.38635fil
 ....\hbox(11.77399+2.66495)x60.22498
 .....\TU/FandolHei(0)/m/n/15.05624 第
 .....\glue 0.0 plus 1.02621
@@ -3233,8 +3231,8 @@ Completed box being shipped out [5]
 ....\kern -0.00017
 ....\kern 0.00017
 ....\penalty 10000
-....\glue(\parfillskip) 0.0
-....\glue(\rightskip) 0.0 plus 1.0fil
+....\glue(\parfillskip) 0.0 plus 1.0fil
+....\glue(\rightskip) 0.0
 ...\write2{\@writefile{toc}{\protect \contentsline {section}{\protect \numberline {第一节}有关图、表和表达式}{\thepage }{}\protected@file@percent }}
 ...\penalty 10000
 ...\penalty 10000

--- a/test/testfiles-crossref/main-bachelor.tlg
+++ b/test/testfiles-crossref/main-bachelor.tlg
@@ -777,7 +777,7 @@ Completed box being shipped out [1]
 ....\special{color pop}
 ..\glue 15.6491
 ..\glue(\lineskip) 0.0
-..\vbox(700.50723+0.0)x417.11752, glue set 346.19151fil
+..\vbox(700.50723+0.0)x417.11752, glue set 382.32265fil
 ...\write-{}
 ...\write-{}
 ...\write-{}
@@ -811,22 +811,22 @@ Completed box being shipped out [1]
 ....\glue(\leftskip) 48.18
 ....\hbox(0.0+0.0)x0.0
 ....\rule(14.05243+6.02255)x0.0
-....\hbox(9.35896+2.21626)x0.0, glue set - 48.18fil
+....\hbox(9.20238+2.15604)x0.0, glue set - 48.18fil
 .....\glue 0.0 plus 1.0fil minus 1.0fil
-.....\hbox(9.35896+2.21626)x48.18
+.....\hbox(9.20238+2.15604)x48.18
 ......\special{color push  Black}
-......\TU/FandolSong(0)/m/n/12.045 第
+......\TU/FandolSong(0)/b/n/12.045 第
 ......\glue 0.0 plus 0.61353
-......\TU/FandolSong(0)/m/n/12.045 一
+......\TU/FandolSong(0)/b/n/12.045 一
 ......\glue 0.0 plus 0.61353
-......\TU/FandolSong(0)/m/n/12.045 章
+......\TU/FandolSong(0)/b/n/12.045 章
 ......\kern -0.00017
 ......\kern 0.00017
 ......\glue 12.045
 ......\special{color pop}
-....\TU/FandolSong(0)/m/n/12.045 引
+....\TU/FandolSong(0)/b/n/12.045 引
 ....\glue 0.0 plus 0.61353
-....\TU/FandolSong(0)/m/n/12.045 言
+....\TU/FandolSong(0)/b/n/12.045 言
 ....\kern -0.00017
 ....\kern 0.00017
 ....\rule(14.05243+6.02255)x0.0
@@ -858,8 +858,8 @@ Completed box being shipped out [1]
 ...\glue(\parskip) 0.0
 ...\glue(\parskip) 0.0
 ...\glue(\baselineskip) 0.00002
-...\hbox(14.05243+6.02255)x417.11752, glue set 203.31882fill
-....\glue(\leftskip) 60.22499
+...\hbox(14.05243+6.02255)x417.11752, glue set 191.27382fill
+....\glue(\leftskip) 72.26999
 ....\hbox(0.0+0.0)x0.0
 ....\rule(14.05243+6.02255)x0.0
 ....\hbox(9.35896+2.144)x0.0, glue set - 48.18fil
@@ -929,8 +929,8 @@ Completed box being shipped out [1]
 ...\glue(\parskip) 0.0
 ...\glue(\parskip) 0.0
 ...\glue(\baselineskip) 0.00002
-...\hbox(14.05243+6.02255)x417.11752, glue set 287.6338fill
-....\glue(\leftskip) 48.18
+...\hbox(14.05243+6.02255)x417.11752, glue set 263.54381fill
+....\glue(\leftskip) 72.26999
 ....\hbox(0.0+0.0)x0.0
 ....\rule(14.05243+6.02255)x0.0
 ....\hbox(4.74573+0.83109)x0.0, glue set - 24.09fil
@@ -983,11 +983,7 @@ Completed box being shipped out [1]
 ....\glue(\parfillskip) 0.0 plus 1.0fil
 ....\glue(\rightskip) 0.0
 ...\penalty 10000
-...\glue 12.045
-...\glue -18.045
 ...\penalty -300
-...\glue 6.0
-...\glue 12.045
 ...\glue 0.0 plus 0.1
 ...\penalty 10000
 ...\glue(\parskip) 0.0
@@ -997,26 +993,26 @@ Completed box being shipped out [1]
 ....\glue(\leftskip) 48.18
 ....\hbox(0.0+0.0)x0.0
 ....\rule(14.05243+6.02255)x0.0
-....\hbox(9.35896+2.21626)x0.0, glue set - 48.18fil
+....\hbox(9.20238+2.15604)x0.0, glue set - 48.18fil
 .....\glue 0.0 plus 1.0fil minus 1.0fil
-.....\hbox(9.35896+2.21626)x48.18
+.....\hbox(9.20238+2.15604)x48.18
 ......\special{color push  Black}
-......\TU/FandolSong(0)/m/n/12.045 第
+......\TU/FandolSong(0)/b/n/12.045 第
 ......\glue 0.0 plus 0.61353
-......\TU/FandolSong(0)/m/n/12.045 二
+......\TU/FandolSong(0)/b/n/12.045 二
 ......\glue 0.0 plus 0.61353
-......\TU/FandolSong(0)/m/n/12.045 章
+......\TU/FandolSong(0)/b/n/12.045 章
 ......\kern -0.00017
 ......\kern 0.00017
 ......\glue 12.045
 ......\special{color pop}
-....\TU/FandolSong(0)/m/n/12.045 内
+....\TU/FandolSong(0)/b/n/12.045 内
 ....\glue 0.0 plus 0.61353
-....\TU/FandolSong(0)/m/n/12.045 容
+....\TU/FandolSong(0)/b/n/12.045 容
 ....\glue 0.0 plus 0.61353
-....\TU/FandolSong(0)/m/n/12.045 要
+....\TU/FandolSong(0)/b/n/12.045 要
 ....\glue 0.0 plus 0.61353
-....\TU/FandolSong(0)/m/n/12.045 素
+....\TU/FandolSong(0)/b/n/12.045 素
 ....\kern -0.00017
 ....\kern 0.00017
 ....\rule(14.05243+6.02255)x0.0
@@ -1048,8 +1044,8 @@ Completed box being shipped out [1]
 ...\glue(\parskip) 0.0
 ...\glue(\parskip) 0.0
 ...\glue(\baselineskip) 0.00002
-...\hbox(14.05243+6.02255)x417.11752, glue set 239.45381fill
-....\glue(\leftskip) 60.22499
+...\hbox(14.05243+6.02255)x417.11752, glue set 227.40881fill
+....\glue(\leftskip) 72.26999
 ....\hbox(0.0+0.0)x0.0
 ....\rule(14.05243+6.02255)x0.0
 ....\hbox(9.35896+2.144)x0.0, glue set - 48.18fil
@@ -1115,8 +1111,8 @@ Completed box being shipped out [1]
 ...\glue(\parskip) 0.0
 ...\glue(\parskip) 0.0
 ...\glue(\baselineskip) 0.00002
-...\hbox(14.05243+6.02255)x417.11752, glue set 335.8138fill
-....\glue(\leftskip) 48.18
+...\hbox(14.05243+6.02255)x417.11752, glue set 311.7238fill
+....\glue(\leftskip) 72.26999
 ....\hbox(0.0+0.0)x0.0
 ....\rule(14.05243+6.02255)x0.0
 ....\hbox(4.74573+0.83109)x0.0, glue set - 24.09fil
@@ -1167,8 +1163,8 @@ Completed box being shipped out [1]
 ...\glue(\parskip) 0.0
 ...\glue(\parskip) 0.0
 ...\glue(\baselineskip) 0.00002
-...\hbox(14.05243+6.02255)x417.11752, glue set 335.8138fill
-....\glue(\leftskip) 48.18
+...\hbox(14.05243+6.02255)x417.11752, glue set 311.7238fill
+....\glue(\leftskip) 72.26999
 ....\hbox(0.0+0.0)x0.0
 ....\rule(14.05243+6.02255)x0.0
 ....\hbox(7.74493+0.83109)x0.0, glue set - 24.09fil
@@ -1219,8 +1215,8 @@ Completed box being shipped out [1]
 ...\glue(\parskip) 0.0
 ...\glue(\parskip) 0.0
 ...\glue(\baselineskip) 0.00002
-...\hbox(14.05243+6.02255)x417.11752, glue set 323.7688fill
-....\glue(\leftskip) 48.18
+...\hbox(14.05243+6.02255)x417.11752, glue set 299.6788fill
+....\glue(\leftskip) 72.26999
 ....\hbox(0.0+0.0)x0.0
 ....\rule(14.05243+6.02255)x0.0
 ....\hbox(8.55196+0.83109)x0.0, glue set - 24.09fil
@@ -1267,11 +1263,7 @@ Completed box being shipped out [1]
 ....\glue(\parfillskip) 0.0 plus 1.0fil
 ....\glue(\rightskip) 0.0
 ...\penalty 10000
-...\glue 12.045
-...\glue -18.045
 ...\penalty -300
-...\glue 6.0
-...\glue 12.045
 ...\glue 0.0 plus 0.1
 ...\penalty 10000
 ...\glue(\parskip) 0.0
@@ -1281,22 +1273,22 @@ Completed box being shipped out [1]
 ....\glue(\leftskip) 48.18
 ....\hbox(0.0+0.0)x0.0
 ....\rule(14.05243+6.02255)x0.0
-....\hbox(9.35896+2.21626)x0.0, glue set - 48.18fil
+....\hbox(9.20238+2.15604)x0.0, glue set - 48.18fil
 .....\glue 0.0 plus 1.0fil minus 1.0fil
-.....\hbox(9.35896+2.21626)x48.18
+.....\hbox(9.20238+2.15604)x48.18
 ......\special{color push  Black}
-......\TU/FandolSong(0)/m/n/12.045 第
+......\TU/FandolSong(0)/b/n/12.045 第
 ......\glue 0.0 plus 0.61353
-......\TU/FandolSong(0)/m/n/12.045 三
+......\TU/FandolSong(0)/b/n/12.045 三
 ......\glue 0.0 plus 0.61353
-......\TU/FandolSong(0)/m/n/12.045 章
+......\TU/FandolSong(0)/b/n/12.045 章
 ......\kern -0.00017
 ......\kern 0.00017
 ......\glue 12.045
 ......\special{color pop}
-....\TU/FandolSong(0)/m/n/12.045 引
+....\TU/FandolSong(0)/b/n/12.045 引
 ....\glue 0.0 plus 0.61353
-....\TU/FandolSong(0)/m/n/12.045 用
+....\TU/FandolSong(0)/b/n/12.045 用
 ....\kern -0.00017
 ....\kern 0.00017
 ....\rule(14.05243+6.02255)x0.0
@@ -1322,11 +1314,7 @@ Completed box being shipped out [1]
 ....\glue(\parfillskip) 0.0 plus 1.0fil
 ....\glue(\rightskip) 0.0
 ...\penalty 10000
-...\glue 12.045
-...\glue -18.045
 ...\penalty 0
-...\glue 6.0
-...\glue 12.045
 ...\glue 0.0 plus 0.1
 ...\penalty 10000
 ...\glue(\parskip) 0.0
@@ -1335,13 +1323,13 @@ Completed box being shipped out [1]
 ...\hbox(14.05243+6.02255)x417.11752, glue set 359.9038fill
 ....\hbox(0.0+0.0)x0.0
 ....\rule(14.05243+6.02255)x0.0
-....\TU/FandolSong(0)/m/n/12.045 参
+....\TU/FandolSong(0)/b/n/12.045 参
 ....\glue 0.0 plus 0.61353
-....\TU/FandolSong(0)/m/n/12.045 考
+....\TU/FandolSong(0)/b/n/12.045 考
 ....\glue 0.0 plus 0.61353
-....\TU/FandolSong(0)/m/n/12.045 文
+....\TU/FandolSong(0)/b/n/12.045 文
 ....\glue 0.0 plus 0.61353
-....\TU/FandolSong(0)/m/n/12.045 献
+....\TU/FandolSong(0)/b/n/12.045 献
 ....\kern -0.00017
 ....\kern 0.00017
 ....\rule(14.05243+6.02255)x0.0
@@ -1377,26 +1365,26 @@ Completed box being shipped out [1]
 ....\glue(\leftskip) 47.84273
 ....\hbox(0.0+0.0)x0.0
 ....\rule(14.05243+6.02255)x0.0
-....\hbox(9.14215+1.99945)x0.0, glue set - 47.84273fil
+....\hbox(8.97353+1.75856)x0.0, glue set - 47.84273fil
 .....\glue 0.0 plus 1.0fil minus 1.0fil
-.....\hbox(9.14215+1.99945)x47.84273
+.....\hbox(8.97353+1.75856)x47.84273
 ......\special{color push  Black}
-......\TU/FandolSong(0)/m/n/12.045 附
+......\TU/FandolSong(0)/b/n/12.045 附
 ......\glue 0.0 plus 0.61353
-......\TU/FandolSong(0)/m/n/12.045 录
+......\TU/FandolSong(0)/b/n/12.045 录
 ......\glue 3.01125 plus 1.5041 minus 1.00473
-......\TU/texgyretermes(0)/m/n/12.045 A
+......\TU/texgyretermes(0)/b/n/12.045 A
 ......\kern -0.0002
 ......\kern 0.0002
 ......\glue 12.045
 ......\special{color pop}
-....\TU/FandolSong(0)/m/n/12.045 附
+....\TU/FandolSong(0)/b/n/12.045 附
 ....\glue 0.0 plus 0.61353
-....\TU/FandolSong(0)/m/n/12.045 录
+....\TU/FandolSong(0)/b/n/12.045 录
 ....\glue 0.0 plus 0.61353
-....\TU/FandolSong(0)/m/n/12.045 章
+....\TU/FandolSong(0)/b/n/12.045 章
 ....\glue 0.0 plus 0.61353
-....\TU/FandolSong(0)/m/n/12.045 节
+....\TU/FandolSong(0)/b/n/12.045 节
 ....\kern -0.00017
 ....\kern 0.00017
 ....\rule(14.05243+6.02255)x0.0
@@ -1431,9 +1419,9 @@ Completed box being shipped out [1]
 ...\hbox(14.05243+6.02255)x417.11752, glue set 377.9713fill
 ....\hbox(0.0+0.0)x0.0
 ....\rule(14.05243+6.02255)x0.0
-....\TU/FandolSong(0)/m/n/12.045 致
+....\TU/FandolSong(0)/b/n/12.045 致
 ....\glue 0.0 plus 0.61353
-....\TU/FandolSong(0)/m/n/12.045 谢
+....\TU/FandolSong(0)/b/n/12.045 谢
 ....\kern -0.00017
 ....\kern 0.00017
 ....\rule(14.05243+6.02255)x0.0
@@ -2021,7 +2009,6 @@ Completed box being shipped out [4]
 ..\vbox(700.50723+0.0)x417.11752, glue set 268.42937fil
 ...\write-{}
 ...\write-{}
-...\write2{\@writefile{toc}{\protect \addvspace {12bp}}}
 ...\write2{\pp@pagectr{footnote}{1}{\theabspage }{\thepage }}
 ...\write2{\@writefile{toc}{\protect \contentsline {chapter}{\protect \numberline {第一章}引言}{\thepage }{}\protected@file@percent }}
 ...\glue(\topskip) 12.0
@@ -3166,7 +3153,6 @@ Completed box being shipped out [5]
 ..\glue(\lineskip) 0.0
 ..\vbox(700.50723+0.0)x417.11752, glue set 6.00505fil
 ...\write-{}
-...\write2{\@writefile{toc}{\protect \addvspace {12bp}}}
 ...\write2{\pp@pagectr{footnote}{2}{\theabspage }{\thepage }}
 ...\write2{\@writefile{toc}{\protect \contentsline {chapter}{\protect \numberline {第二章}内容要素}{\thepage }{}\protected@file@percent }}
 ...\glue(\topskip) 12.0
@@ -4875,7 +4861,6 @@ Completed box being shipped out [7]
 ..\glue(\lineskip) 0.0
 ..\vbox(700.50723+0.0)x417.11752, glue set 630.89862fil
 ...\write-{}
-...\write2{\@writefile{toc}{\protect \addvspace {12bp}}}
 ...\write2{\pp@pagectr{footnote}{3}{\theabspage }{\thepage }}
 ...\write2{\@writefile{toc}{\protect \contentsline {chapter}{\protect \numberline {第三章}引用}{\thepage }{}\protected@file@percent }}
 ...\glue(\topskip) 12.0
@@ -5047,7 +5032,6 @@ Completed box being shipped out [8]
 ..\glue(\lineskip) 0.0
 ..\vbox(700.50723+0.0)x417.11752, glue set 586.44757fil
 ...\write-{}
-...\write2{\@writefile{toc}{\protect \addvspace {12bp}}}
 ...\write2{\@writefile{toc}{\protect \contentsline {chapter}{参考文献}{\thepage }{}\protected@file@percent }}
 ...\glue(\topskip) 12.0
 ...\rule(0.0+0.0)x*

--- a/test/testfiles-crossref/main-bachelor.tlg
+++ b/test/testfiles-crossref/main-bachelor.tlg
@@ -97,10 +97,10 @@ Completed box being shipped out [1]
 ...\glue(\parskip) 0.0
 ...\glue(\parskip) 0.0
 ...\glue(\baselineskip) 19.21178
-...\hbox(13.91197+3.14372)x417.11752, glue set 181.45753fil
+...\hbox(13.91197+3.14372)x417.11752, glue set 190.49127fil
 ....\glue(\leftskip) 0.0 plus 1.0fil
 ....\TU/FandolHei(0)/m/n/18.06749 摘
-....\glue 18.06749 plus 0.1423 minus 2.88081
+....\glue 0.0 plus 0.93489
 ....\TU/FandolHei(0)/m/n/18.06749 要
 ....\kern -0.00017
 ....\kern 0.00017
@@ -792,7 +792,9 @@ Completed box being shipped out [1]
 ...\hbox(13.18927+3.10759)x417.11752, glue set 181.45753fil
 ....\glue(\leftskip) 0.0 plus 1.0fil
 ....\TU/FandolHei(0)/m/n/18.06749 目
-....\glue 18.06749 plus 0.1423 minus 2.88081
+....\kern -0.00017
+....\kern 0.00017
+....\glue 18.06749
 ....\TU/FandolHei(0)/m/n/18.06749 录
 ....\kern -0.00017
 ....\kern 0.00017
@@ -1320,15 +1322,21 @@ Completed box being shipped out [1]
 ...\glue(\parskip) 0.0
 ...\glue(\parskip) 0.0
 ...\glue(\baselineskip) 0.00002
-...\hbox(14.05243+6.02255)x417.11752, glue set 359.9038fill
+...\hbox(14.05243+6.02255)x417.11752, glue set 341.83632fill
 ....\hbox(0.0+0.0)x0.0
 ....\rule(14.05243+6.02255)x0.0
 ....\TU/FandolSong(0)/b/n/12.045 参
-....\glue 0.0 plus 0.61353
+....\kern -0.00017
+....\kern 0.00017
+....\kern 6.02249
 ....\TU/FandolSong(0)/b/n/12.045 考
-....\glue 0.0 plus 0.61353
+....\kern -0.00017
+....\kern 0.00017
+....\kern 6.02249
 ....\TU/FandolSong(0)/b/n/12.045 文
-....\glue 0.0 plus 0.61353
+....\kern -0.00017
+....\kern 0.00017
+....\kern 6.02249
 ....\TU/FandolSong(0)/b/n/12.045 献
 ....\kern -0.00017
 ....\kern 0.00017
@@ -1416,11 +1424,13 @@ Completed box being shipped out [1]
 ...\glue(\parskip) 0.0
 ...\glue(\parskip) 0.0
 ...\glue(\baselineskip) 0.00002
-...\hbox(14.05243+6.02255)x417.11752, glue set 377.9713fill
+...\hbox(14.05243+6.02255)x417.11752, glue set 365.9263fill
 ....\hbox(0.0+0.0)x0.0
 ....\rule(14.05243+6.02255)x0.0
 ....\TU/FandolSong(0)/b/n/12.045 致
-....\glue 0.0 plus 0.61353
+....\kern -0.00017
+....\kern 0.00017
+....\glue 12.045
 ....\TU/FandolSong(0)/b/n/12.045 谢
 ....\kern -0.00017
 ....\kern 0.00017
@@ -1860,14 +1870,14 @@ Completed box being shipped out [3]
 ...\glue(\parskip) 0.0
 ...\glue(\parskip) 0.0
 ...\glue(\baselineskip) 19.13951
-...\hbox(13.98424+3.14372)x417.11752, glue set 158.87318fil
+...\hbox(13.98424+3.14372)x417.11752, glue set 172.42378fil
 ....\glue(\leftskip) 0.0 plus 1.0fil
 ....\TU/FandolHei(0)/m/n/18.06749 符
-....\glue 9.03374 plus 1.40234 minus 0.4979
+....\glue 0.0 plus 0.93489
 ....\TU/FandolHei(0)/m/n/18.06749 号
-....\glue 9.03374 plus 1.40234 minus 0.4979
+....\glue 0.0 plus 0.93489
 ....\TU/FandolHei(0)/m/n/18.06749 说
-....\glue 9.03374 plus 1.40234 minus 0.4979
+....\glue 0.0 plus 0.93489
 ....\TU/FandolHei(0)/m/n/18.06749 明
 ....\kern -0.00017
 ....\kern 0.00017
@@ -5032,7 +5042,7 @@ Completed box being shipped out [8]
 ..\glue(\lineskip) 0.0
 ..\vbox(700.50723+0.0)x417.11752, glue set 586.44757fil
 ...\write-{}
-...\write2{\@writefile{toc}{\protect \contentsline {chapter}{参考文献}{\thepage }{}\protected@file@percent }}
+...\write2{\@writefile{toc}{\protect \contentsline {chapter}{参\protect \enspace  考\protect \enspace  文\protect \enspace  献}{\thepage }{}\protected@file@percent }}
 ...\glue(\topskip) 12.0
 ...\rule(0.0+0.0)x*
 ...\penalty 10000
@@ -5044,11 +5054,17 @@ Completed box being shipped out [8]
 ...\hbox(14.18298+3.39667)x417.11752, glue set 158.87318fil
 ....\glue(\leftskip) 0.0 plus 1.0fil
 ....\TU/FandolHei(0)/m/n/18.06749 参
-....\glue 9.03374 plus 1.40234 minus 0.4979
+....\kern -0.00017
+....\kern 0.00017
+....\kern 9.03374
 ....\TU/FandolHei(0)/m/n/18.06749 考
-....\glue 9.03374 plus 1.40234 minus 0.4979
+....\kern -0.00017
+....\kern 0.00017
+....\kern 9.03374
 ....\TU/FandolHei(0)/m/n/18.06749 文
-....\glue 9.03374 plus 1.40234 minus 0.4979
+....\kern -0.00017
+....\kern 0.00017
+....\kern 9.03374
 ....\TU/FandolHei(0)/m/n/18.06749 献
 ....\kern -0.00017
 ....\kern 0.00017
@@ -5448,7 +5464,7 @@ Completed box being shipped out [10]
 ..\vbox(700.50723+0.0)x417.11752, glue set 566.9528fil
 ...\write-{}
 ...\write-{}
-...\write2{\@writefile{toc}{\protect \contentsline {chapter}{致谢}{\thepage }{}\protected@file@percent }}
+...\write2{\@writefile{toc}{\protect \contentsline {chapter}{致\hskip 1em\relax 谢}{\thepage }{}\protected@file@percent }}
 ...\glue(\topskip) 12.0
 ...\rule(0.0+0.0)x*
 ...\penalty 10000
@@ -5460,7 +5476,9 @@ Completed box being shipped out [10]
 ...\hbox(13.98424+3.30634)x417.11752, glue set 181.45753fil
 ....\glue(\leftskip) 0.0 plus 1.0fil
 ....\TU/FandolHei(0)/m/n/18.06749 致
-....\glue 18.06749 plus 0.1423 minus 2.88081
+....\kern -0.00017
+....\kern 0.00017
+....\glue 18.06749
 ....\TU/FandolHei(0)/m/n/18.06749 谢
 ....\kern -0.00017
 ....\kern 0.00017

--- a/test/testfiles/statement-bachelor.tlg
+++ b/test/testfiles/statement-bachelor.tlg
@@ -102,7 +102,7 @@ Completed box being shipped out [1]
 ....\special{color pop}
 ..\glue 15.6491
 ..\glue(\lineskip) 0.0
-..\vbox(700.50723+0.0)x417.11752, glue set 370.31955fil
+..\vbox(700.50723+0.0)x417.11752, glue set 374.3341fil
 ...\write-{}
 ...\write-{}
 ...\glue(\topskip) 12.0
@@ -557,7 +557,7 @@ Completed box being shipped out [1]
 ...\glue 38.14249
 ...\glue(\parskip) 0.0
 ...\glue(\parskip) 0.0
-...\glue(\baselineskip) 10.48317
+...\glue(\baselineskip) 8.47568
 ...\hbox(9.38306+3.97446)x417.11752, glue set 260.53255fil
 ....\glue(\leftskip) 0.0 plus 1.0fil
 ....\hbox(0.0+0.0)x0.0
@@ -591,7 +591,7 @@ Completed box being shipped out [1]
 ...\glue 12.045
 ...\glue(\parskip) 0.0
 ...\glue(\parskip) 0.0
-...\glue(\baselineskip) 8.7852
+...\glue(\baselineskip) 6.77771
 ...\hbox(9.32283+3.97446)x417.11752, glue set 260.53255fil
 ....\glue(\leftskip) 0.0 plus 1.0fil
 ....\hbox(0.0+0.0)x0.0
@@ -625,14 +625,14 @@ Completed box being shipped out [1]
 ...\glue 0.0 plus 1.0fil
 ...\glue 0.0
 ...\glue 0.0 plus 0.0001fil
-..\glue(\baselineskip) 15.85268
-..\hbox(6.6248+0.0)x417.11752
+..\glue(\baselineskip) 16.45493
+..\hbox(6.02255+0.0)x417.11752
 ...\special{color push  Black}
-...\hbox(6.6248+0.0)x417.11752
-....\hbox(6.6248+0.0)x417.11752
-.....\vbox(6.6248+0.0)x417.11752
+...\hbox(6.02255+0.0)x417.11752
+....\hbox(6.02255+0.0)x417.11752
+.....\vbox(6.02255+0.0)x417.11752
 ......\rule(0.0+0.0)x417.11752
-......\glue 6.6248
+......\glue 6.02255
 ......\hbox(0.0+0.0)x417.11752
 .......\hbox(0.0+0.0)x0.0, glue set - 417.11752fil
 ........\vbox(0.0+0.0)x417.11752

--- a/test/testfiles/title-page-bachelor.tlg
+++ b/test/testfiles/title-page-bachelor.tlg
@@ -47,7 +47,7 @@ Completed box being shipped out [1]
 ....\special{color pop}
 ..\glue 15.6491
 ..\glue(\lineskip) 0.0
-..\vbox(700.50723+0.0)x417.11752, glue set 36.47488fil
+..\vbox(700.50723+0.0)x417.11752, glue set 37.4622fil
 ...\write-{}
 ...\write-{}
 ...\glue(\topskip) 12.0
@@ -131,7 +131,7 @@ Completed box being shipped out [1]
 ...\glue 0.0
 ...\glue(\parskip) 0.0
 ...\glue(\parskip) 0.0
-...\glue(\baselineskip) 1.98743
+...\glue(\lineskip) 1.0
 ...\hbox(20.09506+95.33618)x417.11752
 ....\glue(\leftskip) 0.0 plus 1.0fil
 ....\hbox(0.0+0.0)x0.0

--- a/ustcthesis-doc.tex
+++ b/ustcthesis-doc.tex
@@ -121,9 +121,15 @@
 \section{简介}
 
 本模板 \cls{ustcthesis} 是中国科学技术大学本科生和研究生学位论文的 \LaTeX{}
-模板， 按照《中国科学技术大学研究生学位论文撰写手册》（最近在修订中）和
+模板， 按照研究生院《
+\href{https://gradschool.ustc.edu.cn/column/65}{学位论文撰写模板}
+》（2025-03-31）、教务处《
+\href{https://www.teach.ustc.edu.cn/?attachment_id=19501}
+  {[2025]32号 中国科学技术大学本科毕业论文（设计）质量标准（试行）}
+》和
 《\href{https://www.teach.ustc.edu.cn/?attachment_id=13867}
-{中国科学技术大学本科毕业论文（设计）格式}》的要求编写。
+  {中国科学技术大学本科毕业论文（设计）格式式样}
+》（2026-04-24）的要求编写。
 
 其前身是中国科学技术大学本科论文模板（作者 XPS，最后维护 ywg）
 和中国科学技术大学研究生论文模板（作者 Liuqs，主要维护 Liuqs、Guolicai）。

--- a/ustcthesis.cls
+++ b/ustcthesis.cls
@@ -624,7 +624,7 @@
 
 % 字号
 
-% 正文字号12bp，研究生行距20bp，本科生行距22bp；
+% 正文字号12bp，研究生行距20bp，本科生行距20bp；
 % 其他命令的行距按照相同的的比例设置，如表~\ref{tab:fontsize}。
 % \begin{table}[htb]
 %   \centering
@@ -664,7 +664,7 @@
     % 注意第~\ref{sec:list} 节去掉了列表的间距，所以不再修改 \cs{@listi}。
   \else
     \renewcommand\normalsize{%
-      \@setfontsize\normalsize{12bp}{22bp}%
+      \@setfontsize\normalsize{12bp}{20bp}%
       \abovedisplayskip 6bp \@plus3bp \@minus3bp%
       \abovedisplayshortskip 6bp \@plus3bp \@minus3bp%
       \belowdisplayshortskip \abovedisplayshortskip
@@ -2444,13 +2444,13 @@
       indent    = 0bp,
     },
     subsubsection = {
-      format    = \rmfamily\fontsize{12bp}{22bp}\selectfont,
+      format    = \rmfamily\normalsize,
       number    = \arabic{subsubsection},
       aftername = .\hspace{0.5em},
       indent    = 1em,
     },
     paragraph = {
-      format    = \rmfamily\fontsize{12bp}{22bp}\selectfont,
+      format    = \rmfamily\normalsize,
       number     = （\arabic{paragraph}）,
       aftername = {},
       indent    = 1em,
@@ -2805,7 +2805,7 @@
 \DeclareCaptionFont{ustc}{\ustc@caption@font}
 \newcommand\ustc@caption@font{%
   \ifustc@degree@bachelor
-    \fontsize{12bp}{22bp}\selectfont
+    \normalsize
   \else
     \ifustc@language@chinese
       \fontsize{11bp}{14.3bp}\selectfont

--- a/ustcthesis.cls
+++ b/ustcthesis.cls
@@ -576,16 +576,22 @@
 % 所以“acknowledgements”也保持一致。
 \newcommand\ustc@set@chapter@names{%
   \ifustc@main@language@chinese
-    \def\contentsname{目录}%
+    \ifustc@degree@graduate
+      \def\contentsname{目录}%
+      \def\bibname{参考文献}%
+      \def\ustc@acknowledgements@name{致谢}%
+    \else
+      \def\contentsname{目\quad 录}%
+      \def\bibname{参\enspace 考\enspace 文\enspace 献}%
+      \def\ustc@acknowledgements@name{致\quad 谢}%
+    \fi
     \def\listfigurename{插图清单}%
     \def\listtablename{附表清单}%
     \def\ustc@list@figure@table@name{插图和附表清单}%
     \ctexset{
       chapter/name   = {第,章},
     }%
-    \def\bibname{参考文献}%
     \def\appendixname{附录}%
-    \def\ustc@acknowledgements@name{致谢}%
     \def\ustc@achievements@name{在读期间取得的科研成果}%
     \newcommand\ustc@notation@name{符号说明}%
   \else
@@ -1978,7 +1984,7 @@
 \newcommand\ustc@title@page@graduate@en{%
   \ustcsetup{language=english}%
   \begin{titlepage}%
-    \ustc@pdfbookmark{Title page}%
+    \ustc@pdfbookmark{封面}%
     \centering
     \parbox[t][0bp][t]{\textwidth}{%
       \raggedleft\fangsong\fontsize{14bp}{14bp}\selectfont
@@ -2319,25 +2325,6 @@
   \setcounter{secnumdepth}{3}
 \fi
 
-% 本科生章题为两字时中间空一字，三字时空半字，四字及以上不空。
-% 这里用 \LaTeX3 的 \cs{\str_count:N} 判断字数。
-% 注意，\pkg{stringstrings} 宏包会导致范数命令 \verb+\|+ 被修改。
-\newcount\ustc@titlelength
-\DeclareRobustCommand\ustc@spaced@title[1]{%
-  \ustc@titlelength=\csname str_count:N\endcsname{#1}%
-  \begingroup
-    \if@mainmatter\else
-      \ifcase\ustc@titlelength
-      \or\or
-        \ziju{1}%
-      \or\or
-        \ziju{0.5}%
-      \fi
-    \fi
-    #1%
-  \endgroup
-}
-
 % 五级节标题和脚注需要使用带圈的数字，这里使用 \cs{ustc@circlefont} ：
 \newcommand\ustc@textcircled[1]{%
   \ifnum\value{#1}<21\relax
@@ -2434,7 +2421,7 @@
           \fontsize{18bp}{33bp}\selectfont
         \fi
       },
-      titleformat = \ustc@spaced@title,
+      titleformat = {},
     },
     section = {
       format = \centering\sffamily\fontsize{15bp}{27.5bp}\selectfont,

--- a/ustcthesis.cls
+++ b/ustcthesis.cls
@@ -3465,6 +3465,8 @@
   \pdfstringdefDisableCommands{
     \let\\\@empty
     \let\hspace\@gobble
+    \let\quad\space
+    \let\enspace\space
   }
   %
   % \pkg{hyperref} 与 \pkg{unicode-math} 存在一些兼容性问题，见

--- a/ustcthesis.cls
+++ b/ustcthesis.cls
@@ -2424,7 +2424,7 @@
       titleformat = {},
     },
     section = {
-      format = \centering\sffamily\fontsize{15bp}{27.5bp}\selectfont,
+      format = \sffamily\fontsize{15bp}{27.5bp}\selectfont,
     },
     subsection = {
       format    = \sffamily\fontsize{14bp}{25.67bp}\selectfont,

--- a/ustcthesis.cls
+++ b/ustcthesis.cls
@@ -2623,43 +2623,18 @@
   % 本科生的目录使用小四宋体（同正文字体），其他同研究生的格式相近。
   \titlecontents{chapter}
     [0bp]{}
-    {\contentspush{\thecontentslabel\quad}}{}
-    {\ustc@leaders\thecontentspage}
+    {\bfseries\contentspush{\thecontentslabel\quad}}{\bfseries}
+    {\mdseries\ustc@leaders\thecontentspage}
   \titlecontents{section}
-    [1em]{}
+    [2em]{}
     {\contentspush{\thecontentslabel\quad}}{}
     {\ustc@leaders\thecontentspage}
   \titlecontents{subsection}
-    [2em]{}
+    [4em]{}
     {\contentspush{\thecontentslabel
       \ifustc@section@style@arabic\quad\else 、\fi}}{}
     {\ustc@leaders\thecontentspage}
 \fi
-
-% 本科生要求目录中正文每章前多空一行，而目录、附录等章则不需要空行，
-% 所以不能简单判断 \cs{if@mainmatter}，需要重新定义 \cs{mainmatter} 等命令。
-\newif\ifustc@addtocspace
-\ifustc@degree@bachelor
-  \ustc@addtocspacetrue
-  \g@addto@macro\frontmatter{\ustc@addtocspacefalse}%
-  \g@addto@macro\mainmatter{\ustc@addtocspacetrue}%
-  \g@addto@macro\backmatter{\ustc@addtocspacefalse}%
-  \g@addto@macro\appendix{\ustc@addtocspacefalse}%
-\fi
-
-% 处理本科生在目录中添加空行。
-\renewcommand\chapter{%
-  \if@openright\cleardoublepage\else\clearpage\fi
-  \thispagestyle{\CTEX@chapter@pagestyle}%
-  \global\@topnum\z@
-  \@afterindenttrue
-  \ifustc@degree@bachelor
-    \ifustc@addtocspace
-      \addtocontents{toc}{\protect\addvspace{12bp}}%
-    \fi
-  \fi
-  \secdef\@chapter\@schapter
-}
 
 % 插图和附表清单
 \titlecontents{figure}


### PR DESCRIPTION
- [[2025]32号 中国科学技术大学本科毕业论文（设计）质量标准（试行）.pdf](https://github.com/user-attachments/files/27277138/2025.32.pdf) （2025-09-29）<https://www.teach.ustc.edu.cn/?attachment_id=19501>
- [中国科学技术大学本科毕业论文（设计）格式式样.docx](https://github.com/user-attachments/files/27277219/default.docx) （2026-04-24）<https://www.teach.ustc.edu.cn/?attachment_id=13867>

欢迎继续补充。

- 行距改为 20 磅（#501）。